### PR TITLE
Add RNG seed for Percolator. Fixes #123.

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -838,6 +838,7 @@ process run_percolator {
     """
     PercolatorAdapter -in ${id_file_psm} \\
                        -out ${Sample}_all_ids_merged_psm_perc.idXML \\
+                       -seed 4711 \\
                        -trainFDR 0.05 \\
                        -testFDR 0.05 \\
                        -threads ${task.cpus} \\
@@ -850,6 +851,7 @@ process run_percolator {
     """
     PercolatorAdapter -in ${id_file_psm} \\
                        -out ${Sample}_all_ids_merged_psm_perc.idXML \\
+                       -seed 4711 \\
                        -trainFDR 0.05 \\
                        -testFDR 0.05 \\
                        -threads ${task.cpus} \\
@@ -1041,6 +1043,7 @@ process run_percolator_on_predicted_subset {
      """
      PercolatorAdapter -in ${id_file_psm_subset} \\
                        -out ${Sample}_perc_subset.idXML \\
+                       -seed 4711 \\
                        -trainFDR 0.05 \\
                        -testFDR 0.05 \\
                        -threads ${task.cpus} \\


### PR DESCRIPTION
Percolator uses an RNG. To make the pipeline reproducible, the seed must be fixed.