### PR TITLE
Fix parsing for VEP annotated VCF files

### DIFF
--- a/bin/variants2fasta.py
+++ b/bin/variants2fasta.py
@@ -59,7 +59,7 @@ def read_variant_effect_predictor(file, gene_filter=None):
 
             for co in info.split(","):
                 #Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|DISTANCE|STRAND|FLAGS|SYMBOL_SOURCE|HGNC_ID|TSL|APPRIS|SIFT|PolyPhen|AF|AFR_AF|AMR_AF|EAS_AF|EUR_AF|SAS_AF|AA_AF|EA_AF|gnomAD_AF|gnomAD_AFR_AF|gnomAD_AMR_AF|gnomAD_ASJ_AF|gnomAD_EAS_AF|gnomAD_FIN_AF|gnomAD_NFE_AF|gnomAD_OTH_AF|gnomAD_SAS_AF|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE">
-                _,var_type,_,gene,_,transcript_type,transcript_id,_,_,_,_,_,_,transcript_pos,prot_pos,aa_mutation = co.strip().split("|")[:16]
+                _,var_type,_,gene,_,transcript_type,transcript_id,_,_,_,_,_,transcript_pos,_,prot_pos,aa_mutation = co.strip().split("|")[:16]
                 HGNC_ID=co.strip().split("|")[22]
 
                 #pass every other feature type except Transcript (RegulatoryFeature, MotifFeature.)
@@ -73,7 +73,7 @@ def read_variant_effect_predictor(file, gene_filter=None):
 
                     #positioning in Fred2 is 0-based!!!
                     if transcript_pos != "":
-                        coding[transcript_id] = MutationSyntax(transcript_id, int(transcript_pos)-1,
+                        coding[transcript_id] = MutationSyntax(transcript_id, int(transcript_pos.split('/')[0])-1,
                             -1 if prot_pos  == "" else int(prot_pos)-1, co, "", geneID=HGNC_ID)
 
                 #is variant synonymous?


### PR DESCRIPTION
- Closes #184 
- Crucial change: `transPos` from `FRED2`s `MutationSyntax` is more likely covered with the VEP field `cDNA_position` than `CDS_position` since usually CDS < Transcript
<!--
# nf-core/mhcquant pull request

Many thanks for contributing to nf-core/mhcquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
