### PR TITLE
make ion annotator feature default false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Initial release of nf-core/mhcquant, created with the [nf-core](https://nf-co.re
 - Altered the outcome content with the inclusion of the different folder structure
 - Updated the mhcquant_web.png in the `assets` folder
 - [#229](https://github.com/nf-core/mhcquant/pull/229) Add ion annotation feature requested in [#220](https://github.com/nf-core/mhcquant/issues/220)
-- [#235](https://github.com/nf-core/mhcquant/issues/235) Add the `annotate_ions` parameter to enable/disable the ion annotation feature (default is true)
+- [#235](https://github.com/nf-core/mhcquant/issues/235) Add the `annotate_ions` parameter to enable/disable the ion annotation feature (default is false)
 
 ### `Fixed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,7 +60,7 @@ params {
     use_NL_ions                     = false
     variable_mods                   = 'Oxidation (M)'
     vcf_sheet                       = null
-    annotate_ions                   = true
+    annotate_ions                   = false
 
     // MultiQC options
     skip_multiqc                    = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -234,7 +234,7 @@
                 },
                 "annotate_ions": {
                     "type": "boolean",
-                    "default": "true",
+                    "default": "false",
                     "fa_icon": "fas fa-tags",
                     "description": "Set this option to create documents that are created to perform the ion annotation"
                 }


### PR DESCRIPTION
New Ion annotation feature can potentially produce large output files. This might come with a surprise to users, so we change the feature to default false. #235

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
