### PR TITLE
Added low resolution settings to pipeline

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -73,6 +73,7 @@ process {
                 "-precursor_mass_tolerance ${params.precursor_mass_tolerance}",
                 "-fragment_mass_tolerance ${params.fragment_mass_tolerance}",
                 "-fragment_bin_offset ${params.fragment_bin_offset}",
+                "-instrument ${params.instrument}",
                 "-num_hits ${params.num_hits}",
                 "-digest_mass_range ${params.digest_mass_range}",
                 "-max_variable_mods_in_peptide ${params.number_mods}",

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,8 +33,9 @@ params {
     fdr_threshold                   = 0.01
     fdr_level                       = 'peptide_level_fdrs'
     fixed_mods                      = ' '
-    fragment_bin_offset             = 0
+    fragment_bin_offset             = 0.0
     fragment_mass_tolerance         = 0.02
+    instrument                      = 'high_res'
     klammer                         = false
     max_rt_alignment_shift          = 300
     number_mods                     = 3

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -237,6 +237,12 @@
                     "default": "false",
                     "fa_icon": "fas fa-tags",
                     "description": "Set this option to create documents that are created to perform the ion annotation"
+                },
+                "instrument": {
+                    "type": "string",
+                    "default": "high_res",
+                    "fa_icon": "fas fa-wrench",
+                    "description": "Comets theoretical_fragment_ions parameter: theoretical fragment ion peak representation, high-res: sum of intensities plus flanking bins, ion trap (low-res) ms/ms: sum of intensities of central M bin only"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -124,9 +124,9 @@
                     "help_text": " For High-Resolution instruments a precursor mass tolerance value of 5ppm is recommended. (eg. 5)"
                 },
                 "fragment_bin_offset": {
-                    "type": "integer",
+                    "type": "number",
                     "fa_icon": "fas fa-indent",
-                    "default": 0,
+                    "default": 0.0,
                     "description": "Specify the fragment bin offset to be used for the comet database search.",
                     "help_text": "For High-Resolution instruments a fragment bin offset of 0 is recommended. (See the Comet parameter documentation: eg. 0)"
                 },

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -225,8 +225,7 @@ workflow MHCQUANT {
     // Return an error message when there is only a header present in the document
     OPENMS_TEXTEXPORTER_FDR.out.tsv.map {
         meta, tsv -> if (tsv.size() < 130) {
-            log.error "It seems that there were no significant hits found for one or more samples.\nPlease consider incrementing the '--fdr_threshold' after removing the work directory or to exclude this sample."
-            exit(0)
+            log.warn "It seems that there were no significant hits found for this sample: " + meta.sample + "\nPlease consider incrementing the '--fdr_threshold' after removing the work directory or to exclude this sample. "
         }
     }
 


### PR DESCRIPTION
1) "instrument" parameter was added, which allows specifying high- or low-resolution (e.g. ion trap) instruments.
2) Pipeline does not crash when there are no peptide hits in the sample output. Instead, a warning is thrown.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
