### PR TITLE
fix rawfileparser output bug

### DIFF
--- a/modules/local/thermorawfileparser.nf
+++ b/modules/local/thermorawfileparser.nf
@@ -2,7 +2,7 @@ process THERMORAWFILEPARSER {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::thermorawfileparser=1.4.0" : null)
+    conda (params.enable_conda ? "bioconda::thermorawfileparser=1.4.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/thermorawfileparser:1.4.2--ha8f3691_0' :
         'biocontainers/thermorawfileparser:1.4.2--ha8f3691_0' }"
@@ -25,7 +25,8 @@ process THERMORAWFILEPARSER {
         ThermoRawFileParser.sh \\
             -i $rawfile \\
             -f 2 \\
-            -b ${prefix}.mzML
+            -o .
+
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -170,13 +170,12 @@ workflow MHCQUANT {
     // Raw file conversion
     THERMORAWFILEPARSER(ms_files.raw)
     ch_versions = ch_versions.mix(THERMORAWFILEPARSER.out.versions.ifEmpty(null))
-    // Define the ch_ms_files channels to combine the mzml files
     ch_ms_files = THERMORAWFILEPARSER.out.mzml.mix(ms_files.mzml.map{ it -> [it[0], it[1][0]] })
 
     // timsTOF data conversion
     TDF2MZML(ms_files.tdf)
-    ch_ms_files = TDF2MZML.out.mzml.mix(ms_files.mzml.map{ it -> [it[0], it[1][0]] })
     ch_versions = ch_versions.mix(TDF2MZML.out.versions.ifEmpty(null))   
+    ch_ms_files = TDF2MZML.out.mzml.mix(ms_files.mzml.map{ it -> [it[0], it[1][0]] })
 
     if (params.run_centroidisation) {
         // Optional: Run Peak Picking as Preprocessing


### PR DESCRIPTION
Nextflow seems to have issues with  `-b` output option if new version of thermorawfileparser. Results in empty ms_files channels eventhough the converted files are in the workdir.

Changing to `-o` seems to fix that