### PR TITLE
Fix containerOptions with singularity

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -267,7 +267,6 @@ process {
     }
 
     withName: 'MS2RESCORE' {
-        containerOptions = '-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME'
         ext.args   = [
             "--ms2_tolerance ${2 * params.fragment_mass_tolerance}",
             "--ms2pip_model ${params.ms2pip_model}",

--- a/modules/local/ms2rescore.nf
+++ b/modules/local/ms2rescore.nf
@@ -7,6 +7,9 @@ process MS2RESCORE {
         'https://depot.galaxyproject.org/singularity/ms2rescore:3.0.0--pyhdfd78af_0':
         'biocontainers/ms2rescore:3.0.0--pyhdfd78af_0' }"
 
+    // userEmulation settings when docker is specified
+    containerOptions = (workflow.containerEngine == 'docker') ? '-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME' : ''
+
     input:
     tuple val(meta), path(idxml), path(mzml), path(fasta)
 


### PR DESCRIPTION
This fixes an issue introduced in #302.  The aim was to imitate the depricated `userEmulation` . However, `process.containerOptions` is also used when specifying singularity profile and this obviously results in issues.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
