### PR TITLE
Handle non-indexed spectrum files in chromatogram extractor

### DIFF
--- a/bin/chromatogram_extractor.py
+++ b/bin/chromatogram_extractor.py
@@ -33,16 +33,20 @@ def main():
     # Get RT and Spectrum TIC of MS1 Spectra
     chromatogram = [(spectrum.getRT() / 60 , spectrum.calculateTIC()) for spectrum in exp.getSpectra() if spectrum.getMSLevel() == 1]
     logging.info(f'Found {len(chromatogram)} MS1 Spectra')
-    logging.info(f'RT range: {round(chromatogram[0][0],2)} - {round(chromatogram[-1][0],2)} [min]')
-    # Create pandas df
-    chromatogram_df = pd.DataFrame(chromatogram, columns=['RT', 'TIC'])
-    # bin data into minutes and take the mean of the TIC
-    chromatogram_df = chromatogram_df.groupby('RT').mean().reset_index()
-    # Add RT=0 and Intensity=0 to start and end of chromatogram_df
-    start = pd.DataFrame([{'RT': 0, 'TIC': 0}])
-    end = pd.DataFrame([{'RT': chromatogram_df['RT'].max(), 'TIC': 0}])
-    # Concatenate the DataFrames
-    chromatogram_df = pd.concat([start, chromatogram_df, end], ignore_index=True)
+    try:
+        logging.info(f'RT range: {round(chromatogram[0][0],2)} - {round(chromatogram[-1][0],2)} [min]')
+        # Create pandas df
+        chromatogram_df = pd.DataFrame(chromatogram, columns=['RT', 'TIC'])
+        # bin data into minutes and take the mean of the TIC
+        chromatogram_df = chromatogram_df.groupby('RT').mean().reset_index()
+        # Add RT=0 and Intensity=0 to start and end of chromatogram_df
+        start = pd.DataFrame([{'RT': 0, 'TIC': 0}])
+        end = pd.DataFrame([{'RT': chromatogram_df['RT'].max(), 'TIC': 0}])
+        # Concatenate the DataFrames
+        chromatogram_df = pd.concat([start, chromatogram_df, end], ignore_index=True)
+    except:
+        logging.warning(f'Could not parse spectra. Writing empty file..')
+        chromatogram_df = pd.DataFrame([{'RT': 0, 'TIC': 0}])
 
     # Write to csv
     chromatogram_df.to_csv(output_file, index=False, header=False)


### PR DESCRIPTION
Small PR addressing skipping chromatogram extraction if mzML input is not indexed

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
