### PR TITLE
Support IM2Deep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `-weights` parameter in `OPENMS_PERCOLATORADAPTER` and visualize the median feature weights in multiQC report [#347](https://github.com/nf-core/mhcquant/pull/347)
 - Added flag `generate_speclib` that will generate a spectrum library for DIA searches with EasyPQP [#349](https://github.com/nf-core/mhcquant/pull/349)
 - Replace local with nf-core modules [#350](https://github.com/nf-core/mhcquant/pull/347)
+- Added support for CCS-based rescoring with `IM2Deep` feature generator [#358](https://github.com/nf-core/mhcquant/pull/358)
 
 ### `Fixed`
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ In addition, references of tools and data used in this pipeline are as follows:
 >
 > Declercq A. et al, _Nucleic Acids Res._ 2023 Jul 5;51(W1):W338-W342. doi: [10.1093/nar/gkad335](https://academic.oup.com/nar/article/51/W1/W338/7151340?login=false)
 >
+> **CCS prediction**
+>
+> Declercq A. et al _Journal of Proteome Research_ 2025 Feb 6. doi: [10.1021/acs.jproteome.4c00609](https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00609)
+>
 > **MS²Rescore framework**
 >
 > Buur L. M. et al, \_J Proteome Res. 2024 Mar 16. doi: [10.1021/acs.jproteome.3c00785](https://pubs.acs.org/doi/10.1021/acs.jproteome.3c00785)

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -200,3 +200,9 @@ percolator:
       - "observed_retention_time_best"
       - "rt_diff_best"
       - "observed_retention_time"
+    im2deep:
+      - "ccs_observed_im2deep"
+      - "ccs_predicted_im2deep"
+      - "ccs_error_im2deep"
+      - "abs_ccs_error_im2deep"
+      - "perc_ccs_error_im2deep"

--- a/bin/ms2rescore_cli.py
+++ b/bin/ms2rescore_cli.py
@@ -59,7 +59,6 @@ def parse_cli_arguments_to_config(**kwargs):
                     "write_weights": True,
                     "write_txt": False,
                     "write_flashlfq": False,
-                    "rng": kwargs["rng"],
                     "max_workers": kwargs["processes"],
                 }
             if value == "percolator":
@@ -158,9 +157,6 @@ def filter_out_artifact_psms(
     default=0.15,
 )
 @click.option("-re", "--rescoring_engine", help="Either mokapot or percolator (default: `mokapot`)", default="mokapot")
-@click.option(
-    "-rng", "--rng", help="Seed for mokapot's random number generator (default: `4711`)", type=int, default=4711
-)
 @click.option("-d", "--id_decoy_pattern", help="Regex decoy pattern (default: `DECOY_`)", default="^DECOY_")
 @click.option(
     "-lsb",

--- a/bin/ms2rescore_cli.py
+++ b/bin/ms2rescore_cli.py
@@ -48,6 +48,8 @@ def parse_cli_arguments_to_config(**kwargs):
                 config["ms2rescore"]["feature_generators"]["maxquant"] = {}
             if "ionmob" in feature_generators:
                 config["ms2rescore"]["feature_generators"]["ionmob"] = {}
+            if "im2deep" in feature_generators:
+                config["ms2rescore"]["feature_generators"]["im2deep"] = {}
 
         elif key == "rescoring_engine":
             # Reset rescoring engine dict we want to allow only computing features

--- a/conf/test_timstof.config
+++ b/conf/test_timstof.config
@@ -35,6 +35,6 @@ params {
     spectrum_batch_size      = 1000
 
     // MS²Rescore settings
-    feature_generators       = 'ms2pip'
+    feature_generators       = 'ms2pip,im2deep'
     ms2pip_model             = 'timsTOF'
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ Further information about the command line arguments is documented on the [nf-co
 
 ## Rescoring using MS²Rescore
 
-By default the pipline generates additional features using MS²PIP and DeepLC via the MS²Rescore framework (`--feature_generators deeplc,ms2pip`). Additional feature generators can be added (`basic,deeplc,ms2pip`) to boost identification rates and quality. Please make sure you provide the correct `--ms2pip_model` (default: `Immuno-HCD`). All available MS²PIP models can be found on [GitHub](https://github.com/compomics/ms2pip).
+By default the pipline generates additional features using MS²PIP and DeepLC via the MS²Rescore framework (`--feature_generators deeplc,ms2pip`). Additional feature generators can be added (`basic,deeplc,ms2pip,ionmob,im2deep`) to boost identification rates and quality. Please make sure you provide the correct `--ms2pip_model` (default: `Immuno-HCD`). All available MS²PIP models can be found on [GitHub](https://github.com/compomics/ms2pip).
 
 MS²Rescore creates a comprehensive QC report of the added features used for rescoring. This report is only available if `--rescoring_engine mokapot` is specified (default: `percolator`). The report can be found in `<OUTDIR>/multiqc/ms2rescore`. Further information on the tool itself can be read up in the published paper [Declerq et al. 2022](<https://www.mcponline.org/article/S1535-9476(22)00074-3/fulltext>)
 

--- a/modules/local/ms2rescore.nf
+++ b/modules/local/ms2rescore.nf
@@ -2,10 +2,10 @@ process MS2RESCORE {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::ms2rescore=3.0.1"
+    conda "bioconda::ms2rescore=3.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ms2rescore:3.0.1--pyhdfd78af_2':
-        'biocontainers/ms2rescore:3.0.1--pyhdfd78af_2' }"
+        'https://depot.galaxyproject.org/singularity/ms2rescore:3.1.4--pyh7e72e81_0':
+        'biocontainers/ms2rescore:3.1.4--pyh7e72e81_0' }"
 
     // userEmulation settings when docker is specified
     containerOptions = (workflow.containerEngine == 'docker') ? '-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME' : ''


### PR DESCRIPTION
Add support for CCS predictor `IM2Deep`: https://pubs.acs.org/doi/10.1021/acs.jproteome.4c00609.

Rescoring using CCS values should boost sensitivity even more

![Screenshot 2025-02-26 at 08 51 30](https://github.com/user-attachments/assets/47596c9e-c3a3-410b-b391-75b5e245f202)


IM2Deep features are automatically included in multiQC report

<img width="500" alt="Screenshot 2025-02-25 at 12 10 45" src="https://github.com/user-attachments/assets/2739df81-6f02-4936-a488-318ebe9baee9" />


Add `IM2Deep` to the list of feature generators: `--feature_generators deeplc,ms2pip,im2deep`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
