### PR TITLE
Display low_res settings on Parameters website

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -103,7 +103,6 @@
                     "type": "string",
                     "default": "high_res",
                     "enum": ["high_res", "low_res"],
-                    "hidden": true,
                     "fa_icon": "fas fa-wrench",
                     "description": "Comets theoretical_fragment_ions parameter: theoretical fragment ion peak representation, high_res: sum of intensities plus flanking bins, ion trap (low_res) ms/ms: sum of intensities of central M bin only"
                 },
@@ -166,7 +165,6 @@
                     "type": "number",
                     "fa_icon": "fas fa-pipe",
                     "default": 0.0,
-                    "hidden": true,
                     "description": "Specify the fragment bin offset to be used for the comet database search.",
                     "help_text": "For high-resolution instruments a fragment bin offset of 0 is recommended. (See the Comet parameter documentation: https://uwpr.github.io/Comet/parameters/parameters_202401/).\n This parameter needs to be combined with `fragment_bin_tol` parameter"
                 },


### PR DESCRIPTION
Display settings for `low_res` MS devices, such as LTQ Orbitrap on params tab

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
