### PR TITLE
Coarsen binning for TICs and move general stats to the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue with not providing the full process name in conf/base.config [#384](https://github.com/nf-core/mhcquant/pull/384)
 - Template update 3.1.1, migrate to nf-test [#379](https://github.com/nf-core/mhcquant/pull/379)
+- Fixed the binning of the TICs histogram and move the general stats table to the top of the report [#388](https://github.com/nf-core/mhcquant/pull/388)
 
 ### `Dependencies`
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -24,6 +24,15 @@ run_modules:
 
 # Custom tables and plots
 custom_data:
+  # Summary of general statistics
+  stats_table:
+    plot_type: "table"
+    file_format: "csv"
+    section_name: "General Statistics"
+    pconfig:
+      id: "general_stats"
+      title: "General Statistics"
+
   # Summary of chromatogram plot
   chromatogram:
     plot_type: "linegraph"
@@ -53,14 +62,6 @@ custom_data:
       or parts-per-million (ppm).
     pconfig:
       xlab: "Mass deviation [Da/ppm]"
-
-  stats_table:
-    plot_type: "table"
-    file_format: "csv"
-    section_name: "General Statistics"
-    pconfig:
-      id: "general_stats"
-      title: "General Statistics"
 
   len_plot:
     plot_type: "linegraph"

--- a/bin/chromatogram_extractor.py
+++ b/bin/chromatogram_extractor.py
@@ -31,7 +31,7 @@ def main():
     mzml_file.load(input_file, exp)
 
     # Get RT and Spectrum TIC of MS1 Spectra
-    chromatogram = [(spectrum.getRT() / 60 , spectrum.calculateTIC()) for spectrum in exp.getSpectra() if spectrum.getMSLevel() == 1]
+    chromatogram = [(round(spectrum.getRT() / 60, 1) , spectrum.calculateTIC()) for spectrum in exp.getSpectra() if spectrum.getMSLevel() == 1]
     logging.info(f'Found {len(chromatogram)} MS1 Spectra')
     try:
         logging.info(f'RT range: {round(chromatogram[0][0],2)} - {round(chromatogram[-1][0],2)} [min]')


### PR DESCRIPTION
Coarsen the binning of the TICs histogram and move the general stats table to the top of the report.
<!--
# nf-core/mhcquant pull request

Many thanks for contributing to nf-core/mhcquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
