### PR TITLE
Add unique_accessions column and resolve bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Boxplot of intensity distributions to the MulitQC report [#382](https://github.com/nf-core/mhcquant/pull/382)
 - Added a config option to hide outliers in box plots, add plot descriptions [#387](https://github.com/nf-core/mhcquant/pull/387)
 - Added a `Fasta` column to the input samplesheet to enable sample-specific FASTA files [#391](https://github.com/nf-core/mhcquant/pull/391)
+- Added a column for unique accessions to the pipeline output [#403](https://github.com/nf-core/mhcquant/pull/403)
 
 ### `Fixed`
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the binning of the TICs histogram and move the general stats table to the top of the report [#388](https://github.com/nf-core/mhcquant/pull/388)
 - Write out FDR-filtered peptide list in global FDR-mode, instead of 100% FDR list [#394](https://github.com/nf-core/mhcquant/pull/394/)
 - Update labels for global FDR process configurations [#397](https://github.com/nf-core/mhcquant/pull/397/)
+- Remove special character '#' from the header of OpenMS TextExporter output [#403](https://github.com/nf-core/mhcquant/pull/403)
 
 ### `Dependencies`
 

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -103,6 +103,8 @@ def process_file(file, prefix, quantify, keep_cols):
         n_psms = np.sum(data["psm"])
     else:
         data = pd.read_csv(file, sep='\t')
+        # Remove the special character '#' from the first column name
+        data.rename(columns={data.columns[0]: data.columns[0].replace('#', '')}, inplace=True)
         n_psms = 0
 
     # Check if all required columns are present in the DataFrame

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -190,6 +190,9 @@ def process_file(file, prefix, quantify, keep_cols):
     float_cols = data.select_dtypes(include=['float']).columns
     data.loc[:, float_cols] = data.loc[:, float_cols].round(5)
 
+    # Add a column with unique protein accessions
+    data['unique_accessions'] = data['accessions'].map(lambda x: ';'.join(dict.fromkeys(x.split(';'))))
+
     data.to_csv(f"{prefix}.tsv", sep='\t', index=False)
 
 


### PR DESCRIPTION
<!--
# nf-core/mhcquant pull request

Many thanks for contributing to nf-core/mhcquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
-->

Added a unique_accessions column that contains the unique elements of the accessions column.

The OpenMS TextExporter adds the special character '#' in front of the header with the column names. This leads to the first column (in this case the retention time) not being displayed in the final TSV because the column name '#rt' is not found.
This was resolved.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
