### PR TITLE
Fix #428: add strip_modifications and simplify sequence parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.0dev - [release name] - [date]
+
+### `Fixed`
+- Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)
+
 ## 3.1.0 - BlüBa - 07/01/26
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 3.2.0dev - [release name] - [date]
 
 ### `Fixed`
+
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)
 
 ## 3.1.0 - BlüBa - 07/01/26

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -4,6 +4,7 @@
 
 import pandas as pd
 import numpy as np
+from pyopenms import AASequence
 from argparse import ArgumentParser
 import re
 from collections import Counter
@@ -87,7 +88,14 @@ def parse_multiTSV(file_path):
     df["psm"] = df["sequence"].map(psm)
     return df
 
-
+def strip_modifications(seq_with_mods: str) -> str:
+    try:
+        aa_seq = AASequence.fromString(seq_with_mods)
+        return aa_seq.toUnmodifiedString()
+    except Exception as e:
+        logging.warning(f"Could not parse sequence {seq_with_mods}: {e}")
+        return seq_with_mods
+    
 def process_file(file, prefix, quantify, keep_cols):
     """Extract all the relevant information and write it to a TSV file for the MultiQC report
 
@@ -122,7 +130,7 @@ def process_file(file, prefix, quantify, keep_cols):
 
     # Remove modification information from the sequence column
     data["peptidoform"] = data["sequence"]
-    data["sequence"] = data["sequence"].apply(lambda seq: re.sub(r'\(.*?\)', '', seq))
+    data["sequence"] = data["sequence"].apply(strip_modifications)
 
     # ---------------------------------
     # Length distribution plot

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -95,7 +95,7 @@ def strip_modifications(seq_with_mods: str) -> str:
     except Exception as e:
         logging.warning(f"Could not parse sequence {seq_with_mods}: {e}")
         return seq_with_mods
-    
+
 def process_file(file, prefix, quantify, keep_cols):
     """Extract all the relevant information and write it to a TSV file for the MultiQC report
 


### PR DESCRIPTION
Added function 'strip_modifications' to parse sequences. The --variable_mods flag is no longer required. Verified to work with all standard labels.

<!--
# nf-core/mhcquant pull request

Many thanks for contributing to nf-core/mhcquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
