### PR TITLE
Add ion mobility export and MultiQC distribution plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - Added support for single run quantification [#438](https://github.com/nf-core/mhcquant/pull/438)
+- Added ion mobility (IM) export and MultiQC distribution plot for timsTOF data [#441](https://github.com/nf-core/mhcquant/pull/441)
 
 ### `Fixed`
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -102,6 +102,19 @@ custom_data:
       xlab: "Retention time"
       ylab: "Frequency"
 
+  im_plot:
+    plot_type: "linegraph"
+    file_format: "csv"
+    section_name: "Ion Mobility"
+    description: |
+      This plot shows the distribution of ion mobility (1/K0) values for identified peptides.
+      Ion mobility data is available when using instruments with ion mobility separation (e.g., timsTOF).
+    pconfig:
+      id: "histogram_im"
+      title: "Ion Mobility Distribution"
+      xlab: "Ion Mobility (1/K0) [V·s/cm²]"
+      ylab: "Frequency"
+
   qvalue_plot:
     plot_type: "linegraph"
     file_format: "csv"
@@ -164,6 +177,8 @@ sp:
     fn: "*_histogram_mz.csv"
   rt_plot:
     fn: "*_histogram_rt.csv"
+  im_plot:
+    fn: "*_histogram_im.csv"
   qvalue_plot:
     fn: "*_histogram_scores.csv"
   scores_plot_xcorr:

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -158,6 +158,10 @@ def process_file(file, prefix, quantify, keep_cols):
     # Histograms
     # ---------------------------------
 
+    # Rename IM column to ion_mobility for readability
+    if "IM" in data.columns:
+        data.rename(columns={"IM": "ion_mobility"}, inplace=True)
+
     histograms = [[data["mz"].astype(float), f"{prefix}_histogram_mz.csv"],
                   [data["rt"].astype(float), f"{prefix}_histogram_rt.csv"],
                   [data["score"].astype(float), f"{prefix}_histogram_scores.csv"]]
@@ -165,6 +169,15 @@ def process_file(file, prefix, quantify, keep_cols):
     for values, title in histograms:
         hist, bin_edges = np.histogram(values, bins='auto')
         with open(title, "w") as f:
+            for i in range(len(bin_edges) - 1):
+                bin_midpoint = (bin_edges[i] + bin_edges[i + 1]) / 2
+                f.write(f'{bin_midpoint},{hist[i]}\n')
+
+    # Generate ion mobility histogram if IM data is available (e.g., timsTOF)
+    if "ion_mobility" in data.columns:
+        im_values = data["ion_mobility"].astype(float)
+        hist, bin_edges = np.histogram(im_values, bins='auto')
+        with open(f"{prefix}_histogram_im.csv", "w") as f:
             for i in range(len(bin_edges) - 1):
                 bin_midpoint = (bin_edges[i] + bin_edges[i + 1]) / 2
                 f.write(f'{bin_midpoint},{hist[i]}\n')

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -472,7 +472,8 @@ process {
                 "observed_retention_time_best", "predicted_retention_time_best",
                 "spec_pearson",
                 "std_abs_diff",
-                "ccs_observed_im2deep", "ccs_predicted_im2deep", "ccs_error_im2deep"
+                "ccs_observed_im2deep", "ccs_predicted_im2deep", "ccs_error_im2deep",
+                "ion_mobility"
             ].join(',').trim(),
         ].join(' ').trim()
         publishDir  = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -472,7 +472,7 @@ process {
                 "observed_retention_time_best", "predicted_retention_time_best",
                 "spec_pearson",
                 "std_abs_diff",
-                "ccs_observed_im2deep", "ccs_predicted_im2deep", "ccs_error_im2deep",
+"ccs_predicted_im2deep", "ccs_error_im2deep",
                 "ion_mobility"
             ].join(',').trim(),
         ].join(' ').trim()

--- a/modules/local/openms/textexporter/main.nf
+++ b/modules/local/openms/textexporter/main.nf
@@ -27,6 +27,7 @@ process OPENMS_TEXTEXPORTER {
         -out ${prefix}_exported.tsv \\
         -threads $task.cpus \\
         -id:add_hit_metavalues 0 \\
+        -id:add_metavalues 0 \\
         -id:peptides_only \\
         $args
     """

--- a/modules/local/pyopenms/summarize_results/main.nf
+++ b/modules/local/pyopenms/summarize_results/main.nf
@@ -15,6 +15,7 @@ process SUMMARIZE_RESULTS {
     path '*_xcorr_scores.csv'                                   , emit: xcorr, optional: true
     path '*_peptide_length.csv'                                 , emit: lengths, optional: true
     path '*_peptide_intensity.csv'                              , emit: intensities, optional: true
+    path '*_histogram_im.csv'                                   , emit: hist_im, optional: true
     tuple val(meta), path('*.tsv'), path('*_general_stats.csv') , emit: epicore_input
     tuple val("${task.process}"), val('pyopenms'), eval("pip show pyopenms | grep Version | sed 's/Version: //'"), topic: versions
 
@@ -41,6 +42,7 @@ process SUMMARIZE_RESULTS {
     touch ${prefix}_xcorr_scores.csv
     touch ${prefix}_peptide_length.csv
     touch ${prefix}_peptide_intensity.csv
+    touch ${prefix}_histogram_im.csv
     touch ${prefix}_general_stats.csv
     touch ${prefix}.tsv
     """

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -209,6 +209,7 @@ workflow MHCQUANT {
         SUMMARIZE_RESULTS.out.hist_mz,
         SUMMARIZE_RESULTS.out.hist_rt,
         SUMMARIZE_RESULTS.out.hist_scores,
+        SUMMARIZE_RESULTS.out.hist_im,
         SUMMARIZE_RESULTS.out.xcorr,
         SUMMARIZE_RESULTS.out.lengths,
         SUMMARIZE_RESULTS.out.intensities,


### PR DESCRIPTION
## Summary
- Enables ion mobility (IM) export from TextExporter by adding `-id:add_metavalues 0` flag (closes #440)
- Renames the `IM` column to `ion_mobility` in the final output TSV for readability
- Generates an IM histogram CSV and renders it as an "Ion Mobility Distribution" linegraph in the MultiQC report
- Gracefully skips IM output for non-timsTOF data (all IM outputs are `optional: true`)

## Changes
- `modules/local/openms/textexporter/main.nf` — add `-id:add_metavalues 0` to export PeptideIdentification-level meta values
- `bin/summarize_results.py` — rename `IM` → `ion_mobility`, generate `*_histogram_im.csv`
- `modules/local/pyopenms/summarize_results/main.nf` — add `hist_im` output channel (optional)
- `workflows/mhcquant.nf` — wire `hist_im` into `ch_multiqc_files`
- `conf/modules.config` — add `ion_mobility` to SUMMARIZE_RESULTS `--columns`
- `assets/multiqc_config.yml` — add `im_plot` custom data entry and search pattern