### PR TITLE
Bump easypqp version to 0.1.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Dependency | Old version | New version |
 | ---------- | ----------- | ----------- |
+| `easypqp`  | 0.1.53      | 0.1.57      |
 | `MultiQC`  | 1.31.0      | 1.33.0      |
 | `Nf-core`  | 3.4.1       | 3.5.1       |
 | `openms`   | 3.4.1       | 3.5.0       |

--- a/modules/local/easypqp/convert/environment.yml
+++ b/modules/local/easypqp/convert/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::easypqp=0.1.53
+  - bioconda::easypqp=0.1.57

--- a/modules/local/easypqp/convert/main.nf
+++ b/modules/local/easypqp/convert/main.nf
@@ -4,8 +4,8 @@ process EASYPQP_CONVERT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/easypqp:0.1.53--pyhdfd78af_0' :
-        'biocontainers/easypqp:0.1.53--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_0' :
+        'biocontainers/easypqp:0.1.57--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(pepxml), path(spectra)

--- a/modules/local/easypqp/convert/main.nf
+++ b/modules/local/easypqp/convert/main.nf
@@ -4,8 +4,8 @@ process EASYPQP_CONVERT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_0' :
-        'biocontainers/easypqp:0.1.57--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_1' :
+        'biocontainers/easypqp:0.1.57--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(pepxml), path(spectra)

--- a/modules/local/easypqp/library/environment.yml
+++ b/modules/local/easypqp/library/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::easypqp=0.1.53
+  - bioconda::easypqp=0.1.57

--- a/modules/local/easypqp/library/main.nf
+++ b/modules/local/easypqp/library/main.nf
@@ -4,8 +4,8 @@ process EASYPQP_LIBRARY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_0' :
-        'biocontainers/easypqp:0.1.57--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_1' :
+        'biocontainers/easypqp:0.1.57--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(psmpkl), path(peakpkl)

--- a/modules/local/easypqp/library/main.nf
+++ b/modules/local/easypqp/library/main.nf
@@ -4,8 +4,8 @@ process EASYPQP_LIBRARY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/easypqp:0.1.53--pyhdfd78af_0' :
-        'biocontainers/easypqp:0.1.53--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/easypqp:0.1.57--pyhdfd78af_0' :
+        'biocontainers/easypqp:0.1.57--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(psmpkl), path(peakpkl)

--- a/tests/speclib.nf.test.snap
+++ b/tests/speclib.nf.test.snap
@@ -4,10 +4,10 @@
             28,
             {
                 "EASYPQP_CONVERT": {
-                    "easypqp": "0.1.53"
+                    "easypqp": "0.1.57"
                 },
                 "EASYPQP_LIBRARY": {
-                    "easypqp": "0.1.53"
+                    "easypqp": "0.1.57"
                 },
                 "MS2RESCORE": {
                     "MS2Rescore": "3.1.5"


### PR DESCRIPTION
Critical version bump fixing an easypqp bug that prevents two digit ion fragments in speclib output. https://github.com/grosenberger/easypqp/issues/143

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
