### PR TITLE
Fix global FDR null:null precursor length by propagating search params in meta

### DIFF
--- a/subworkflows/local/rescore/main.nf
+++ b/subworkflows/local/rescore/main.nf
@@ -8,8 +8,10 @@
 
 include { MS2RESCORE                                                  } from '../../../modules/local/ms2rescore'
 include { OPENMS_PSMFEATUREEXTRACTOR                                  } from '../../../modules/local/openms/psmfeatureextractor'
-include { OPENMS_PERCOLATORADAPTER;
-        OPENMS_PERCOLATORADAPTER as OPENMS_PERCOLATORADAPTER_GLOBAL } from '../../../modules/local/openmsthirdparty/percolatoradapter'
+include {
+    OPENMS_PERCOLATORADAPTER ;
+    OPENMS_PERCOLATORADAPTER as OPENMS_PERCOLATORADAPTER_GLOBAL
+} from '../../../modules/local/openmsthirdparty/percolatoradapter'
 include { OPENMS_TEXTEXPORTER as OPENMS_TEXTEXPORTER_GLOBAL           } from '../../../modules/local/openms/textexporter'
 //
 // MODULE: Installed directly from nf-core/modules
@@ -17,49 +19,48 @@ include { OPENMS_TEXTEXPORTER as OPENMS_TEXTEXPORTER_GLOBAL           } from '..
 
 include { OPENMS_IDMERGER as OPENMS_IDMERGER_GLOBAL                   } from '../../../modules/nf-core/openms/idmerger/main'
 include { OPENMS_IDSCORESWITCHER                                      } from '../../../modules/nf-core/openms/idscoreswitcher/main.nf'
-include { OPENMS_IDFILTER as OPENMS_IDFILTER_Q_VALUE;
-        OPENMS_IDFILTER as OPENMS_IDFILTER_Q_VALUE_GLOBAL;
-        OPENMS_IDFILTER as OPENMS_IDFILTER_GLOBAL                   } from '../../../modules/nf-core/openms/idfilter/main'
+include {
+    OPENMS_IDFILTER as OPENMS_IDFILTER_Q_VALUE ;
+    OPENMS_IDFILTER as OPENMS_IDFILTER_Q_VALUE_GLOBAL ;
+    OPENMS_IDFILTER as OPENMS_IDFILTER_GLOBAL
+} from '../../../modules/nf-core/openms/idfilter/main'
 
 workflow RESCORE {
-
     take:
-        ch_merged_runs
-        ch_multiqc_files
+    ch_merged_runs
+    ch_multiqc_files
 
     main:
     // Compute features via ms2rescore
     MS2RESCORE(ch_merged_runs)
 
     if (params.rescoring_engine == 'mokapot') {
-        log.warn "The rescoring engine is set to mokapot. This rescoring engine currently only supports psm-level-fdr via ms2rescore."
+        log.warn("The rescoring engine is set to mokapot. This rescoring engine currently only supports psm-level-fdr via ms2rescore.")
         if (params.global_fdr) {
-            log.warn "Global FDR is currently not supported by mokapot. The global_fdr parameter will be ignored."
+            log.warn("Global FDR is currently not supported by mokapot. The global_fdr parameter will be ignored.")
         }
         // Switch comet e-value to mokapot q-value
         OPENMS_IDSCORESWITCHER(MS2RESCORE.out.idxml)
         ch_rescored_runs = OPENMS_IDSCORESWITCHER.out.idxml
 
         // Filter by mokapot q-value
-        OPENMS_IDFILTER_Q_VALUE(ch_rescored_runs.map {group_meta, idxml -> [group_meta, idxml, []]})
+        OPENMS_IDFILTER_Q_VALUE(ch_rescored_runs.map { group_meta, idxml -> [group_meta, idxml, []] })
         ch_filter_q_value = OPENMS_IDFILTER_Q_VALUE.out.filtered
-
-    } else {
+    }
+    else {
         // Extract PSM features for Percolator
         OPENMS_PSMFEATUREEXTRACTOR(MS2RESCORE.out.idxml.join(MS2RESCORE.out.feature_names))
 
         // Run Percolator with local FDR
         OPENMS_PERCOLATORADAPTER(OPENMS_PSMFEATUREEXTRACTOR.out.idxml)
-        ch_multiqc_files = ch_multiqc_files.mix(OPENMS_PERCOLATORADAPTER.out.feature_weights.map{ meta, feature_weights -> feature_weights })
+        ch_multiqc_files = ch_multiqc_files.mix(OPENMS_PERCOLATORADAPTER.out.feature_weights.map { meta, feature_weights -> feature_weights })
         ch_pout = OPENMS_PERCOLATORADAPTER.out.idxml
 
         if (params.global_fdr) {
             // Group by search_preset for global FDR. Samples without a preset all share
             // the same params (CLI or defaults), so they correctly group under 'global'.
             OPENMS_IDMERGER_GLOBAL(
-                OPENMS_PSMFEATUREEXTRACTOR.out.idxml
-                    .map { group_meta, idxml -> [[id: group_meta.search_preset ?: 'global'], idxml] }
-                    .groupTuple()
+                OPENMS_PSMFEATUREEXTRACTOR.out.idxml.map { group_meta, idxml -> [group_meta + [id: group_meta.search_preset ?: 'global'], idxml] }.groupTuple()
             )
             // Run Percolator with global FDR (one per preset group)
             OPENMS_PERCOLATORADAPTER_GLOBAL(OPENMS_IDMERGER_GLOBAL.out.idxml)
@@ -68,33 +69,29 @@ workflow RESCORE {
             OPENMS_IDFILTER_Q_VALUE_GLOBAL(ch_rescored_runs.map { id, idxml -> [id, idxml, []] })
             // Backfilter: match each local file with its corresponding preset's global FDR file
             OPENMS_IDFILTER_GLOBAL(
-                ch_pout
-                    .map { group_meta, idxml ->
-                        [group_meta.search_preset ?: 'global', group_meta, idxml]
-                    }
-                    .combine(
-                        OPENMS_IDFILTER_Q_VALUE_GLOBAL.out.filtered
-                            .map { global_meta, idxml -> [global_meta.id, idxml] },
-                        by: 0
-                    )
-                    .map { preset, group_meta, local_idxml, global_filtered_idxml ->
-                        [group_meta, local_idxml, global_filtered_idxml]
-                    }
+                ch_pout.map { group_meta, idxml ->
+                    [group_meta.search_preset ?: 'global', group_meta, idxml]
+                }.combine(
+                    OPENMS_IDFILTER_Q_VALUE_GLOBAL.out.filtered.map { global_meta, idxml -> [global_meta.id, idxml] },
+                    by: 0
+                ).map { preset, group_meta, local_idxml, global_filtered_idxml ->
+                    [group_meta, local_idxml, global_filtered_idxml]
+                }
             )
             ch_filter_q_value = OPENMS_IDFILTER_GLOBAL.out.filtered
             // Save globally merged runs in tsv (one per preset group)
             OPENMS_TEXTEXPORTER_GLOBAL(OPENMS_IDFILTER_Q_VALUE_GLOBAL.out.filtered)
-
-        } else {
+        }
+        else {
             ch_rescored_runs = ch_pout
             // Filter by percolator q-value
-            OPENMS_IDFILTER_Q_VALUE(ch_rescored_runs.map {group_meta, idxml -> [group_meta, idxml, []]})
+            OPENMS_IDFILTER_Q_VALUE(ch_rescored_runs.map { group_meta, idxml -> [group_meta, idxml, []] })
             ch_filter_q_value = OPENMS_IDFILTER_Q_VALUE.out.filtered
         }
     }
 
     emit:
-        rescored_runs = ch_rescored_runs.map { meta, file -> [[id: meta.id], file] }
-        fdr_filtered = ch_filter_q_value.map { meta, file -> [[id: meta.id], file] }
-        multiqc_files = ch_multiqc_files
+    rescored_runs = ch_rescored_runs.map { meta, file -> [[id: meta.id], file] }
+    fdr_filtered  = ch_filter_q_value.map { meta, file -> [[id: meta.id], file] }
+    multiqc_files = ch_multiqc_files
 }

--- a/subworkflows/local/speclib/main.nf
+++ b/subworkflows/local/speclib/main.nf
@@ -6,8 +6,8 @@
 // MODULE: Loaded from modules/local/
 //
 
-include { EASYPQP_CONVERT                         } from '../../../modules/local/easypqp/convert'
-include { EASYPQP_LIBRARY                         } from '../../../modules/local/easypqp/library'
+include { EASYPQP_CONVERT                           } from '../../../modules/local/easypqp/convert'
+include { EASYPQP_LIBRARY                           } from '../../../modules/local/easypqp/library'
 include { EASYPQP_LIBRARY as EASYPQP_LIBRARY_GLOBAL } from '../../../modules/local/easypqp/library'
 
 //
@@ -15,14 +15,13 @@ include { EASYPQP_LIBRARY as EASYPQP_LIBRARY_GLOBAL } from '../../../modules/loc
 //
 
 workflow SPECLIB {
-
     take:
-        fdrfiltered_comet_idxml
-        mzml
+    fdrfiltered_comet_idxml
+    mzml
 
     main:
     // Load unimod tables (Future:)
-    unimod = file("$projectDir/assets/250120_unimod_tables.xml", checkIfExists: true)
+    unimod = file("${projectDir}/assets/250120_unimod_tables.xml", checkIfExists: true)
 
     // Convert psms and spectra to pickle files
     EASYPQP_CONVERT(fdrfiltered_comet_idxml.join(mzml), unimod)
@@ -42,11 +41,11 @@ workflow SPECLIB {
     // Generate spectrum library for all MSruns in the samplesheet
     if (params.global_fdr) {
         EASYPQP_CONVERT.out.psmpkl
-            .map { meta, psmpkl -> [[id: "global"], psmpkl] }
+            .map { meta, psmpkl -> [meta + [id: "global"], psmpkl] }
             .groupTuple()
             .set { ch_global_psmpkl }
         EASYPQP_CONVERT.out.peakpkl
-            .map { meta, peakpkl -> [[id: "global"], peakpkl] }
+            .map { meta, peakpkl -> [meta + [id: "global"], peakpkl] }
             .groupTuple()
             .set { ch_global_peakpkl }
         EASYPQP_LIBRARY_GLOBAL(ch_global_psmpkl.join(ch_global_peakpkl))

--- a/subworkflows/local/speclib/main.nf
+++ b/subworkflows/local/speclib/main.nf
@@ -41,11 +41,11 @@ workflow SPECLIB {
     // Generate spectrum library for all MSruns in the samplesheet
     if (params.global_fdr) {
         EASYPQP_CONVERT.out.psmpkl
-            .map { meta, psmpkl -> [meta + [id: meta.search_preset ?: 'global'], psmpkl] }
+            .map { meta, psmpkl -> [[id: meta.search_preset ?: 'global'], psmpkl] }
             .groupTuple()
             .set { ch_global_psmpkl }
         EASYPQP_CONVERT.out.peakpkl
-            .map { meta, peakpkl -> [meta + [id: meta.search_preset ?: 'global'], peakpkl] }
+            .map { meta, peakpkl -> [[id: meta.search_preset ?: 'global'], peakpkl] }
             .groupTuple()
             .set { ch_global_peakpkl }
         EASYPQP_LIBRARY_GLOBAL(ch_global_psmpkl.join(ch_global_peakpkl))

--- a/subworkflows/local/speclib/main.nf
+++ b/subworkflows/local/speclib/main.nf
@@ -41,11 +41,11 @@ workflow SPECLIB {
     // Generate spectrum library for all MSruns in the samplesheet
     if (params.global_fdr) {
         EASYPQP_CONVERT.out.psmpkl
-            .map { meta, psmpkl -> [meta + [id: "global"], psmpkl] }
+            .map { meta, psmpkl -> [meta + [id: meta.search_preset ?: 'global'], psmpkl] }
             .groupTuple()
             .set { ch_global_psmpkl }
         EASYPQP_CONVERT.out.peakpkl
-            .map { meta, peakpkl -> [meta + [id: "global"], peakpkl] }
+            .map { meta, peakpkl -> [meta + [id: meta.search_preset ?: 'global'], peakpkl] }
             .groupTuple()
             .set { ch_global_peakpkl }
         EASYPQP_LIBRARY_GLOBAL(ch_global_psmpkl.join(ch_global_peakpkl))


### PR DESCRIPTION
## Description

When using `--global_fdr`, the `OPENMS_IDFILTER_Q_VALUE_GLOBAL` process failed with:

```
Could not convert string 'null:null' to a range of integer values
```

**Root cause:** In `rescore/main.nf`, the global FDR grouping created a new meta map with only `[id: ...]`, discarding all search params (including `peptide_min_length` and `peptide_max_length`). The `modules.config` then interpolated `${meta.peptide_min_length}:${meta.peptide_max_length}` as `null:null`.

**Fix:** Propagate the full `group_meta` (which already has per-sample fields stripped upstream in `mhcquant.nf`) into the global meta via `group_meta + [id: group_meta.search_preset ?: 'global']`. This dynamically preserves all search params without hardcoding field names.

Additionally fixed `speclib/main.nf` to group by `search_preset` instead of hardcoded `"global"`, so samples with different presets produce separate spectrum libraries.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).