### PR TITLE
Fix SUMMARIZE_RESULTS crash with --quantify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)
 
 ### `Changed`

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -78,6 +78,15 @@ def parse_multiTSV(file_path):
             elif line.startswith("#UNASSIGNEDPEPTIDE"):
                 unassigned_peptide_cols = line.strip().split('\t')[1:]
 
+    # Workaround for OpenMS 3.5.0 TextExporter bug (https://github.com/OpenMS/OpenMS/issues/9120):
+    # consensusXML export writes a phantom column in data rows between 'end' and 'FFId_category'
+    # that is missing from the header. Remove it to realign columns.
+    for rows, cols in [(peptide_rows, peptide_cols), (unassigned_peptide_rows, unassigned_peptide_cols)]:
+        if rows and len(rows[0]) > len(cols) and 'end' in cols:
+            extra_idx = cols.index('end') + 1
+            for i, row in enumerate(rows):
+                rows[i] = row[:extra_idx] + row[extra_idx + 1:]
+
     peptide_df = pd.DataFrame(peptide_rows, columns=peptide_cols)
     consensus_df = pd.DataFrame(consensus_rows, columns=consensus_cols)
     # Concatenate CONSENSUS and PEPTIDE columns
@@ -195,6 +204,10 @@ def process_file(file, prefix, quantify, keep_cols):
             header=False
         )
 
+    # Add a column with unique protein accessions next to accessions
+    data.insert(data.columns.get_loc('accessions') + 1, 'unique_accessions',
+                data['accessions'].map(lambda x: ';'.join(dict.fromkeys(x.split(';')))))
+
     # Filter the columns down to a user-defined subset of columns
     if keep_cols:
         missing_columns = set(keep_cols) - set(data.columns)
@@ -205,6 +218,10 @@ def process_file(file, prefix, quantify, keep_cols):
         regex_patterns = [r'^rt_', r'^mz_', r'^intensity_', r'^charge_']
         for pattern in regex_patterns:
             keep_cols.extend([col for col in data.columns if re.match(pattern, col)])
+        # Always include unique_accessions next to accessions
+        if 'accessions' in keep_cols and 'unique_accessions' not in keep_cols:
+            idx = keep_cols.index('accessions') + 1
+            keep_cols.insert(idx, 'unique_accessions')
         # Remove duplicates while retaining order
         keep_cols = list(dict.fromkeys(keep_cols))
         data = data.loc[:, keep_cols]
@@ -212,9 +229,6 @@ def process_file(file, prefix, quantify, keep_cols):
     # Round all floating point values to 5 decimal places to ensure nf-test checksum stability is guaranteed
     float_cols = data.select_dtypes(include=['float']).columns
     data.loc[:, float_cols] = data.loc[:, float_cols].round(5)
-
-    # Add a column with unique protein accessions
-    data['unique_accessions'] = data['accessions'].map(lambda x: ';'.join(dict.fromkeys(x.split(';'))))
 
     data.to_csv(f"{prefix}.tsv", sep='\t', index=False)
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -449,6 +449,7 @@ process {
     }
 
     withName: 'OPENMS_TEXTEXPORTER' {
+        ext.args    = '-id:peptides_only -id:add_hit_metavalues 0 -id:add_metavalues 0'
         publishDir  = [
             enabled: false
         ]
@@ -473,8 +474,7 @@ process {
                 "observed_retention_time_best", "predicted_retention_time_best",
                 "spec_pearson",
                 "std_abs_diff",
-"ccs_predicted_im2deep", "ccs_error_im2deep",
-                "ion_mobility"
+                "ccs_predicted_im2deep", "ccs_error_im2deep", "ion_mobility"
             ].join(',').trim(),
         ].join(' ').trim()
         publishDir  = [

--- a/modules/local/openms/textexporter/main.nf
+++ b/modules/local/openms/textexporter/main.nf
@@ -26,9 +26,6 @@ process OPENMS_TEXTEXPORTER {
         -in $file \\
         -out ${prefix}_exported.tsv \\
         -threads $task.cpus \\
-        -id:add_hit_metavalues 0 \\
-        -id:add_metavalues 0 \\
-        -id:peptides_only \\
         $args
     """
 


### PR DESCRIPTION
## Description

Fixes the `SUMMARIZE_RESULTS` process crash when running with `--quantify`. The crash was caused by an [OpenMS 3.5.0 TextExporter bug](https://github.com/OpenMS/OpenMS/issues/9120) that writes a phantom `-1` column in PEPTIDE/UNASSIGNEDPEPTIDE data rows when exporting consensusXML, but omits the corresponding column from the header — resulting in a `ValueError: 123 columns passed, passed data had 124 columns` in `parse_multiTSV()`.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).