### PR TITLE
fix: EPICORE runs only once when --fasta is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#PR](https://github.com/nf-core/mhcquant/pull/PR)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#PR](https://github.com/nf-core/mhcquant/pull/PR)
+- Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)
 

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -204,7 +204,7 @@ workflow MHCQUANT {
     // EPICORE
     //
     if (params.epicore) {
-        EPICORE(ch_fasta.map{ fasta -> fasta.last()}, SUMMARIZE_RESULTS.out.epicore_input)
+        EPICORE(ch_fasta.map{ fasta -> fasta.last()}.first(), SUMMARIZE_RESULTS.out.epicore_input)
         ch_multiqc_files = ch_multiqc_files.mix(
             EPICORE.out.length_dist,
             EPICORE.out.intensity_hist


### PR DESCRIPTION
## Symptom

When running the pipeline with `--epicore` and `--fasta <file>`, only **one** `results/<sample>.tsv` file is produced, regardless of how many samples were processed. For an N-sample run, only the first sample to reach `SUMMARIZE_RESULTS` gets an EPICORE output; the rest are silently dropped. No error is raised.

Confirmed on a user run: 14 `SUMMARIZE_RESULTS` tasks completed, but only 1 `EPICORE` task was ever submitted.

## Root cause

In `subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf` (~line 139), when `--fasta` is set, `ch_fasta` is built with `channel.fromPath(params.fasta, ...)` — a **queue** channel carrying a single item, not a value channel.

In `workflows/mhcquant.nf:207`, that one-item queue channel is paired with `SUMMARIZE_RESULTS.out.epicore_input` (an N-item queue channel, one item per sample/condition group). Nextflow pairs queue-to-queue positionally: the fasta channel drains after the first iteration and the remaining N-1 `epicore_input` items never trigger an `EPICORE` task.

Because `conf/modules.config` sets `SUMMARIZE_RESULTS.publishDir.enabled = !params.epicore`, EPICORE's TSV is what the user sees in `results/` when `--epicore` is on — so the missing runs translate directly into missing output files.

Introduced in the `fix/summarize-result-quant` merge (#444, commit `b046949`), which first wired `EPICORE` in with this call signature.

## Fix

One character — `.first()` converts the single-item queue channel into a value channel, which broadcasts to every matching item in the other channel:

```diff
-        EPICORE(ch_fasta.map{ fasta -> fasta.last()}, SUMMARIZE_RESULTS.out.epicore_input)
+        EPICORE(ch_fasta.map{ fasta -> fasta.last()}.first(), SUMMARIZE_RESULTS.out.epicore_input)
```

## Behavior

- **Multi-sample runs with `--fasta --epicore`:** now produces one `results/<sample>.tsv` per sample (previously one total).
- **Single-sample runs:** unchanged — broadcasting a one-item value channel to a one-item queue channel produces the same single pairing as before.
- **Samplesheet-provided FASTA (no `--fasta`):** unchanged — this code path constructs `ch_fasta` differently and is not affected by this fix.

## Files changed

- `workflows/mhcquant.nf` — one-character fix on line 207
- `CHANGELOG.md` — `### Fixed` entry under `3.2.0dev`