### PR TITLE
Pin tdf2mzml container to 0.4_noentry

### DIFF
--- a/modules/local/tdf2mzml/main.nf
+++ b/modules/local/tdf2mzml/main.nf
@@ -1,7 +1,7 @@
 process TDF2MZML {
     tag "$meta.id"
 
-    container "docker.io/mfreitas/tdf2mzml"
+    container "docker.io/mfreitas/tdf2mzml:0.4_noentry"
 
     input:
     tuple val(meta), path(tdf)
@@ -9,13 +9,13 @@ process TDF2MZML {
     output:
     tuple val(meta), path("*.mzML"), emit: mzml
     tuple val("${task.process}"), val('python'), eval("python3 --version | cut -d ' ' -f2"), topic: versions
-    tuple val("${task.process}"), val('tdf2mzml'), eval("echo 0.3.0"), topic: versions
+    tuple val("${task.process}"), val('tdf2mzml'), eval("tdf2mzml --version | cut -d' ' -f2"), topic: versions
 
     script:
     def prefix = task.ext.prefix ?: "${tdf.simpleName}"
 
     """
-    tdf2mzml.py -i $tdf -o ${prefix}.mzML
+    tdf2mzml -i $tdf -o ${prefix}.mzML
     """
 
     stub:


### PR DESCRIPTION
Fix for this issue: https://github.com/mafreitas/tdf2mzml/issues/26

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
