### PR TITLE
Skip QUANT for empty FDR-filtered samples (#427)

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -90,18 +90,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Disk inventory (probe, remove after)
-        run: |
-          echo "=== root df ==="; df -h /
-          echo ""
-          echo "=== top 30 largest dirs under /opt, /usr/share, /usr/local ==="
-          sudo du -sh /opt/* /usr/share/* /usr/local/* 2>/dev/null | sort -h | tail -30
-          echo ""
-          echo "=== specifically asked ==="
-          ls -ld /opt/az /usr/share/swift /usr/local/julia* /opt/google /opt/microsoft /opt/pipx /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache 2>&1 || true
-
       - name: Disk space cleanup
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+
+      - name: Remove unused RunsOn AMI tooling
+        run: |
+          sudo rm -rf \
+            /opt/az \
+            /opt/google \
+            /opt/microsoft \
+            /usr/share/miniconda \
+            /usr/local/aws-cli \
+            /opt/aws \
+            /usr/local/aws-sam-cli \
+            /usr/share/gradle-9.5.1 || true
+          df -h /
 
       - name: Run nf-test
         id: run_nf_test

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -90,6 +90,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Disk inventory (probe, remove after)
+        run: |
+          echo "=== root df ==="; df -h /
+          echo ""
+          echo "=== top 30 largest dirs under /opt, /usr/share, /usr/local ==="
+          sudo du -sh /opt/* /usr/share/* /usr/local/* 2>/dev/null | sort -h | tail -30
+          echo ""
+          echo "=== specifically asked ==="
+          ls -ld /opt/az /usr/share/swift /usr/local/julia* /opt/google /opt/microsoft /opt/pipx /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache 2>&1 || true
+
       - name: Disk space cleanup
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=40gb
     strategy:
       fail-fast: false
       matrix:
@@ -92,19 +93,6 @@ jobs:
 
       - name: Disk space cleanup
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-
-      - name: Remove unused RunsOn AMI tooling
-        run: |
-          sudo rm -rf \
-            /opt/az \
-            /opt/google \
-            /opt/microsoft \
-            /usr/share/miniconda \
-            /usr/local/aws-cli \
-            /opt/aws \
-            /usr/local/aws-sam-cli \
-            /usr/share/gradle-9.5.1 || true
-          df -h /
 
       - name: Run nf-test
         id: run_nf_test

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -90,6 +90,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Disk space cleanup
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+
       - name: Run nf-test
         id: run_nf_test
         uses: ./.github/actions/nf-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - Fixed crashes in `FeatureLinkerUnlabeledKD` and `PYOPENMS_IONANNOTATOR` for samples with zero peptides past FDR; empty samples now emit an empty TSV [#451](https://github.com/nf-core/mhcquant/pull/451)
+- Fixed `OPENMS_FILECONVERTER` version eval emitting a `\x01` control character into the MultiQC versions YAML due to an unescaped sed backreference [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed nf-test CI failures caused by Docker layer extraction running out of disk space when pulling `ms2rescore` and OpenMS 3.5.0 containers; added `jlumbroso/free-disk-space` cleanup step before nf-test [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fixed pipeline crash in `FeatureLinkerUnlabeledKD` when a sample has zero peptides past FDR filtering; QUANT is now skipped for empty samples and an empty TSV is written instead [#427](https://github.com/nf-core/mhcquant/issues/427)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Fixed pipeline crash in `FeatureLinkerUnlabeledKD` when a sample has zero peptides past FDR filtering; QUANT is now skipped for empty samples and an empty TSV is written instead [#451](https://github.com/nf-core/mhcquant/pull/451)
+- Fixed crashes in `FeatureLinkerUnlabeledKD` and `PYOPENMS_IONANNOTATOR` for samples with zero peptides past FDR; empty samples now emit an empty TSV [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed nf-test CI failures caused by Docker layer extraction running out of disk space when pulling `ms2rescore` and OpenMS 3.5.0 containers; added `jlumbroso/free-disk-space` cleanup step before nf-test [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed crashes in `FeatureLinkerUnlabeledKD` and `PYOPENMS_IONANNOTATOR` for samples with zero peptides past FDR; empty samples now emit an empty TSV [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `OPENMS_FILECONVERTER` version eval emitting a `\x01` control character into the MultiQC versions YAML due to an unescaped sed backreference [#451](https://github.com/nf-core/mhcquant/pull/451)
-- Fixed nf-test CI failures caused by Docker layer extraction running out of disk space when pulling `ms2rescore` and OpenMS 3.5.0 containers; added `jlumbroso/free-disk-space` cleanup step before nf-test [#451](https://github.com/nf-core/mhcquant/pull/451)
+- Fixed nf-test CI failures caused by Docker layer extraction running out of disk space when pulling `ms2rescore` and OpenMS 3.5.0 containers; added `jlumbroso/free-disk-space` cleanup step and bumped the RunsOn disk to `volume=40gb` [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Fixed pipeline crash in `FeatureLinkerUnlabeledKD` when a sample has zero peptides past FDR filtering; QUANT is now skipped for empty samples and an empty TSV is written instead [#427](https://github.com/nf-core/mhcquant/issues/427)
+- Fixed pipeline crash in `FeatureLinkerUnlabeledKD` when a sample has zero peptides past FDR filtering; QUANT is now skipped for empty samples and an empty TSV is written instead [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - Fixed pipeline crash in `FeatureLinkerUnlabeledKD` when a sample has zero peptides past FDR filtering; QUANT is now skipped for empty samples and an empty TSV is written instead [#451](https://github.com/nf-core/mhcquant/pull/451)
+- Fixed nf-test CI failures caused by Docker layer extraction running out of disk space when pulling `ms2rescore` and OpenMS 3.5.0 containers; added `jlumbroso/free-disk-space` cleanup step before nf-test [#451](https://github.com/nf-core/mhcquant/pull/451)
 - Fixed `EPICORE` running only once instead of per sample when `--fasta` is used, by broadcasting `ch_fasta` to `EPICORE` via `.first()` [#446](https://github.com/nf-core/mhcquant/pull/446)
 - Fixed `SUMMARIZE_RESULTS` crash with `--quantify` caused by OpenMS 3.5.0 TextExporter phantom column bug ([OpenMS/OpenMS#9120](https://github.com/OpenMS/OpenMS/issues/9120)) [#444](https://github.com/nf-core/mhcquant/pull/444)
 - Fixed an issue where stripping the sequence in `SUMMARIZE_RESULTS` did not work for complex modifications [#436](https://github.com/nf-core/mhcquant/pull/436)

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -105,11 +105,11 @@ def strip_modifications(seq_with_mods: str) -> str:
         logging.warning(f"Could not parse sequence {seq_with_mods}: {e}")
         return seq_with_mods
 
-def is_multi_tsv(file_path):
-    """A multi-TSV (quant) export has lines starting with #PEPTIDE / #CONSENSUS."""
+def multi_tsv_not_empty(file_path):
+    """A populated multi-TSV (quant) export has PEPTIDE/CONSENSUS data rows (no leading #)."""
     with open(file_path) as f:
         for line in f:
-            if line.startswith('#PEPTIDE') or line.startswith('#CONSENSUS'):
+            if line.startswith('PEPTIDE\t') or line.startswith('CONSENSUS\t'):
                 return True
     return False
 
@@ -120,10 +120,10 @@ def process_file(file, prefix, quantify, keep_cols):
        Args:
            file (str): The file location of the TSV file
            prefix (str): The prefix for all the output files
-           quantify (bool): Retained for CLI back-compat only; format is auto-detected.
+           quantify (bool): Whether quantification mode is enabled
            keep_cols (list): Set of columns to keep from the original set of columns
        """
-    if is_multi_tsv(file):
+    if quantify and multi_tsv_not_empty(file):
         data = parse_multiTSV(file)
         n_psms = np.sum(data["psm"])
     else:

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -123,7 +123,6 @@ def process_file(file, prefix, quantify, keep_cols):
            quantify (bool): Retained for CLI back-compat only; format is auto-detected.
            keep_cols (list): Set of columns to keep from the original set of columns
        """
-    # Auto-detect format: multi-TSV (quant consensusXML) vs flat TSV (idXML / empty bypass)
     if is_multi_tsv(file):
         data = parse_multiTSV(file)
         n_psms = np.sum(data["psm"])

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -105,17 +105,26 @@ def strip_modifications(seq_with_mods: str) -> str:
         logging.warning(f"Could not parse sequence {seq_with_mods}: {e}")
         return seq_with_mods
 
+def is_multi_tsv(file_path):
+    """A multi-TSV (quant) export has lines starting with #PEPTIDE / #CONSENSUS."""
+    with open(file_path) as f:
+        for line in f:
+            if line.startswith('#PEPTIDE') or line.startswith('#CONSENSUS'):
+                return True
+    return False
+
+
 def process_file(file, prefix, quantify, keep_cols):
     """Extract all the relevant information and write it to a TSV file for the MultiQC report
 
        Args:
            file (str): The file location of the TSV file
            prefix (str): The prefix for all the output files
-           quantify (bool): Whether quantification mode is enabled
+           quantify (bool): Retained for CLI back-compat only; format is auto-detected.
            keep_cols (list): Set of columns to keep from the original set of columns
        """
-    # If quantification is enabled, parse multiTSV output, otherwise the TSV file already has the correct format
-    if quantify:
+    # Auto-detect format: multi-TSV (quant consensusXML) vs flat TSV (idXML / empty bypass)
+    if is_multi_tsv(file):
         data = parse_multiTSV(file)
         n_psms = np.sum(data["psm"])
     else:

--- a/conf/base.config
+++ b/conf/base.config
@@ -58,10 +58,10 @@ process {
         errorStrategy = 'retry'
         maxRetries    = 2
     }
-    withName:NFCORE_MHCQUANT:MHCQUANT:PREPARE_SPECTRA:TDF2MZML {
-        cpus   = { 1     * task.attempt, 'cpus'   }
-        memory = { 10.GB * task.attempt, 'memory' }
-        time   = { 16.h  * task.attempt, 'time'   }
+    withName: 'TDF2MZML' {
+        cpus   = { 1     * task.attempt }
+        memory = { 10.GB * task.attempt }
+        time   = { 16.h  * task.attempt }
     }
     withName: 'PRIDEPY_FETCH_SDRF' {
         errorStrategy = 'retry'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -273,37 +273,31 @@ process {
 }
 
 process {
-    if (params.quantify) {
-        withName: 'NFCORE_MHCQUANT:MHCQUANT:QUANT:OPENMS_IDSCORESWITCHER' {
-            ext.args   = [
-                "-new_score COMET:xcorr",
-                "-new_score_orientation higher_better",
-                "-old_score q-value"
-            ].join(' ').trim()
-            publishDir  = [
-                mode: params.publish_dir_mode,
-                pattern: '*.idXML',
-                enabled: false
-            ]
-        }
+    withName: 'NFCORE_MHCQUANT:MHCQUANT:QUANT:OPENMS_IDSCORESWITCHER' {
+        ext.args   = [
+            "-new_score COMET:xcorr",
+            "-new_score_orientation higher_better",
+            "-old_score q-value"
+        ].join(' ').trim()
+        publishDir  = [
+            mode: params.publish_dir_mode,
+            pattern: '*.idXML',
+            enabled: false
+        ]
     }
-}
 
-process {
-    if (params.rescoring_engine == 'mokapot') {
-        withName: 'NFCORE_MHCQUANT:MHCQUANT:RESCORE:OPENMS_IDSCORESWITCHER' {
-            ext.prefix  = {"${meta.id}"}
-            ext.args   = [
-                "-new_score q-value",
-                "-new_score_orientation lower_better",
-                "-old_score expect"
-            ].join(' ').trim()
-            publishDir  = [
-                mode: params.publish_dir_mode,
-                pattern: '*.idXML',
-                enabled: false
-            ]
-        }
+    withName: 'NFCORE_MHCQUANT:MHCQUANT:RESCORE:OPENMS_IDSCORESWITCHER' {
+        ext.prefix  = {"${meta.id}"}
+        ext.args   = [
+            "-new_score q-value",
+            "-new_score_orientation lower_better",
+            "-old_score expect"
+        ].join(' ').trim()
+        publishDir  = [
+            mode: params.publish_dir_mode,
+            pattern: '*.idXML',
+            enabled: false
+        ]
     }
 }
 
@@ -546,19 +540,16 @@ process {
 }
 
 process {
-
-    if (params.annotate_ions) {
-        withName: 'PYOPENMS_IONANNOTATOR' {
-            ext.args   = { [
-                    "--precursor_charge ${meta.prec_charge}",
-                    "--fragment_mass_tolerance ${meta.fragment_mass_tolerance}",
-                    "--remove_precursor_peak ${params.remove_precursor_peak}"
-                ].join(' ').trim() }
-                publishDir  = [
-                    path: {"${params.outdir}/intermediate_results/ion_annotations"},
-                    mode: params.publish_dir_mode,
-                    pattern: '*.tsv'
-                ]
-        }
+    withName: 'PYOPENMS_IONANNOTATOR' {
+        ext.args   = { [
+            "--precursor_charge ${meta.prec_charge}",
+            "--fragment_mass_tolerance ${meta.fragment_mass_tolerance}",
+            "--remove_precursor_peak ${params.remove_precursor_peak}"
+        ].join(' ').trim() }
+        publishDir  = [
+            path: {"${params.outdir}/intermediate_results/ion_annotations"},
+            mode: params.publish_dir_mode,
+            pattern: '*.tsv'
+        ]
     }
 }

--- a/modules/local/openms/fileconverter/main.nf
+++ b/modules/local/openms/fileconverter/main.nf
@@ -12,7 +12,7 @@ process OPENMS_FILECONVERTER {
 
     output:
     tuple val(meta), path("*.${suffix}"), emit: consensusxml
-    tuple val("${task.process}"), val('openms'), eval("FileInfo --help 2>&1 | sed -nE 's/^Version: ([0-9.]+).*/\1/p'"), topic: versions
+    tuple val("${task.process}"), val('openms'), eval("FileInfo --help 2>&1 | sed -nE 's/^Version: ([0-9.]+).*/\\1/p'"), topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/nextflow.config
+++ b/nextflow.config
@@ -232,7 +232,6 @@ profiles {
     test              { includeConfig 'conf/test.config'              }
     test_sdrf         { includeConfig 'conf/test_sdrf.config'         }
     test_mokapot      { includeConfig 'conf/test_mokapot.config'      }
-    test_percolator   { includeConfig 'conf/test_percolator.config'   }
     test_ionannotator { includeConfig 'conf/test_ionannotator.config' }
     test_speclib      { includeConfig 'conf/test_speclib.config'      }
     test_timstof      { includeConfig 'conf/test_timstof.config'      }

--- a/nextflow.config
+++ b/nextflow.config
@@ -234,7 +234,6 @@ profiles {
     test_mokapot      { includeConfig 'conf/test_mokapot.config'      }
     test_percolator   { includeConfig 'conf/test_percolator.config'   }
     test_ionannotator { includeConfig 'conf/test_ionannotator.config' }
-    test_epicore      { includeConfig 'conf/test_epicore.config'      }
     test_speclib      { includeConfig 'conf/test_speclib.config'      }
     test_timstof      { includeConfig 'conf/test_timstof.config'      }
     test_single_quant   { includeConfig 'conf/test_single_quant.config'   }

--- a/subworkflows/local/rescore/main.nf
+++ b/subworkflows/local/rescore/main.nf
@@ -90,8 +90,18 @@ workflow RESCORE {
         }
     }
 
+    ch_filter_q_value
+        .map { meta, file -> [[id: meta.id], file] }
+        .branch {
+            // Empty FDR-filtered idXML (no peptides) is ~120 lines of OpenMS scaffolding.
+            non_empty: it[1].countLines() > 130
+            empty:     true
+        }
+        .set { ch_fdr_branched }
+
     emit:
-    rescored_runs = ch_rescored_runs.map { meta, file -> [[id: meta.id], file] }
-    fdr_filtered  = ch_filter_q_value.map { meta, file -> [[id: meta.id], file] }
-    multiqc_files = ch_multiqc_files
+    rescored_runs      = ch_rescored_runs.map { meta, file -> [[id: meta.id], file] }
+    fdr_filtered       = ch_fdr_branched.non_empty
+    fdr_filtered_empty = ch_fdr_branched.empty
+    multiqc_files      = ch_multiqc_files
 }

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -165,10 +165,7 @@ workflow MHCQUANT {
     // SUBWORKFLOW: QUANT
     //
     if (params.quantify) {
-        // Branch out samples with empty FDR-filtered idXMLs (zero peptides past FDR).
-        // Re-uses the same countLines() > 130 heuristic as the SPECLIB path above.
-        // Use `it[1]` (matches subworkflows/local/process_feature/main.nf:23) — destructuring
-        // inside .branch can swallow the labels.
+        // Empty FDR-filtered idXML (no peptides) is ~26 lines of OpenMS scaffolding.
         RESCORE.out.fdr_filtered
             .branch {
                 non_empty: it[1].countLines() > 130
@@ -176,8 +173,6 @@ workflow MHCQUANT {
             }
             .set { ch_fdr_branched }
 
-        // Warn per empty sample; .subscribe matches the nf-core idiom used at
-        // subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf:180
         ch_fdr_branched.empty.subscribe { item ->
             log.warn """\
                 No peptides passed FDR filtering for sample '${item[0].id}'.
@@ -209,8 +204,6 @@ workflow MHCQUANT {
         PYOPENMS_IONANNOTATOR( ch_ion_annotator_input )
     }
 
-    // Export ID/quant result to TSV (handles both idXML and consensusXML inputs).
-    // Per-sample emptiness warnings are emitted earlier (see QUANT branch above).
     OPENMS_TEXTEXPORTER(ch_output)
 
     // Process the tsv file to facilitate visualization with MultiQC

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -141,6 +141,14 @@ workflow MHCQUANT {
     RESCORE( ch_rescore_in, ch_multiqc_files )
     ch_multiqc_files = ch_multiqc_files.mix(RESCORE.out.multiqc_files)
 
+    RESCORE.out.fdr_filtered_empty.subscribe { item ->
+        log.warn """\
+            No peptides passed FDR filtering for sample '${item[0].id}'.
+            An empty TSV will be written.
+            Consider raising '--fdr_threshold' or excluding this sample.
+            """.stripIndent()
+    }
+
     // GENERATE SPECTRUM LIBRARY
     if (params.generate_speclib) {
         OPENMSTHIRDPARTY_COMETADAPTER.out.idxml
@@ -151,40 +159,21 @@ workflow MHCQUANT {
 
         // Backfilter Comet identifications with FDR threshold
         OPENMS_IDFILTER_FOR_SPECLIB(ch_fdrfilter_comet_idxml)
-            .filtered
-            .filter { meta, idxml -> idxml.countLines() > 130 }
-            .set { ch_fdrfilter_comet_idxml_filtered }
 
         //
         // SUBWORKFLOW: SPECLIB
         //
-        SPECLIB(ch_fdrfilter_comet_idxml_filtered, ch_clean_mzml_file)
+        SPECLIB(OPENMS_IDFILTER_FOR_SPECLIB.out.filtered, ch_clean_mzml_file)
     }
 
     //
     // SUBWORKFLOW: QUANT
     //
     if (params.quantify) {
-        // Empty FDR-filtered idXML (no peptides) is ~26 lines of OpenMS scaffolding.
-        RESCORE.out.fdr_filtered
-            .branch {
-                non_empty: it[1].countLines() > 130
-                empty:     true
-            }
-            .set { ch_fdr_branched }
-
-        ch_fdr_branched.empty.subscribe { item ->
-            log.warn """\
-                No peptides passed FDR filtering for sample '${item[0].id}'.
-                Skipping quantification for this sample; an empty TSV will be written.
-                Consider raising '--fdr_threshold' or excluding this sample.
-                """.stripIndent()
-        }
-
-        QUANT(merge_meta_map, RESCORE.out.rescored_runs, ch_fdr_branched.non_empty, ch_clean_mzml_file)
-        ch_output = QUANT.out.consensusxml.mix(ch_fdr_branched.empty)
+        QUANT(merge_meta_map, RESCORE.out.rescored_runs, RESCORE.out.fdr_filtered, ch_clean_mzml_file)
+        ch_output = QUANT.out.consensusxml.mix(RESCORE.out.fdr_filtered_empty)
     } else {
-        ch_output = RESCORE.out.fdr_filtered
+        ch_output = RESCORE.out.fdr_filtered.mix(RESCORE.out.fdr_filtered_empty)
     }
 
     // Annotate Ions for follow-up spectrum validation

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -165,8 +165,29 @@ workflow MHCQUANT {
     // SUBWORKFLOW: QUANT
     //
     if (params.quantify) {
-        QUANT(merge_meta_map, RESCORE.out.rescored_runs, RESCORE.out.fdr_filtered, ch_clean_mzml_file)
-        ch_output = QUANT.out.consensusxml
+        // Branch out samples with empty FDR-filtered idXMLs (zero peptides past FDR).
+        // Re-uses the same countLines() > 130 heuristic as the SPECLIB path above.
+        // Use `it[1]` (matches subworkflows/local/process_feature/main.nf:23) — destructuring
+        // inside .branch can swallow the labels.
+        RESCORE.out.fdr_filtered
+            .branch {
+                non_empty: it[1].countLines() > 130
+                empty:     true
+            }
+            .set { ch_fdr_branched }
+
+        // Warn per empty sample; .subscribe matches the nf-core idiom used at
+        // subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf:180
+        ch_fdr_branched.empty.subscribe { item ->
+            log.warn """\
+                No peptides passed FDR filtering for sample '${item[0].id}'.
+                Skipping quantification for this sample; an empty TSV will be written.
+                Consider raising '--fdr_threshold' or excluding this sample.
+                """.stripIndent()
+        }
+
+        QUANT(merge_meta_map, RESCORE.out.rescored_runs, ch_fdr_branched.non_empty, ch_clean_mzml_file)
+        ch_output = QUANT.out.consensusxml.mix(ch_fdr_branched.empty)
     } else {
         ch_output = RESCORE.out.fdr_filtered
     }
@@ -188,14 +209,9 @@ workflow MHCQUANT {
         PYOPENMS_IONANNOTATOR( ch_ion_annotator_input )
     }
 
-    // Prepare for check if file is empty
+    // Export ID/quant result to TSV (handles both idXML and consensusXML inputs).
+    // Per-sample emptiness warnings are emitted earlier (see QUANT branch above).
     OPENMS_TEXTEXPORTER(ch_output)
-    // Return an error message when there is only a header present in the document
-    OPENMS_TEXTEXPORTER.out.tsv.map {
-        meta, tsv -> if (tsv.size() < 130) {
-        log.warn "It seems that there were no significant hits found for this sample: " + meta.sample + "\nPlease consider incrementing the '--fdr_threshold' after removing the work directory or to exclude this sample. "
-        }
-    }
 
     // Process the tsv file to facilitate visualization with MultiQC
     SUMMARIZE_RESULTS(OPENMS_TEXTEXPORTER.out.tsv)


### PR DESCRIPTION
Closes #427: skip QUANT for samples whose FDR-filtered idXML is empty and write an empty TSV instead of crashing in `FeatureLinkerUnlabeledKD`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).