### PR TITLE
Fix UNTAR/UNZIP/EPICORE version eval crashing on compressed .d input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Fixed `UNTAR`, `UNZIP` and `EPICORE` version capture aborting the process: the `echo $(...)` `eval` form spliced parenthesis-containing version banners into the `bash -c` command, breaking every compressed Bruker `.d` input [#455](https://github.com/nf-core/mhcquant/pull/455)
+- Fixed `UNTAR`, `UNZIP` and `EPICORE` version `eval` crashing on parenthesis-containing tool banners [#455](https://github.com/nf-core/mhcquant/pull/455)
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.3.0dev
 
+### `Fixed`
+
+- Fixed `UNTAR`, `UNZIP` and `EPICORE` version capture aborting the process: the `echo $(...)` `eval` form spliced parenthesis-containing version banners into the `bash -c` command, breaking every compressed Bruker `.d` input [#455](https://github.com/nf-core/mhcquant/pull/455)
+
 ### `Changed`
 
 - Updated to nf-core template 4.0.2 [#454](https://github.com/nf-core/mhcquant/pull/454)

--- a/modules/local/epicore/main.nf
+++ b/modules/local/epicore/main.nf
@@ -16,7 +16,7 @@ process EPICORE {
         path "${result_tsv}",                       emit: final_epicore_tsv
         path "epicore_length_distribution.html",    emit: length_dist
         path "epicore_intensity_histogram.html",    emit: intensity_hist
-        tuple val("${task.process}"), val('epicore'), eval("epicore --version | grep 'epicore' | cut -d ' ' -f3 | cut -c2-"), topic: versions
+        tuple val("${task.process}"), val('epicore'), eval("epicore --version 2>&1 | grep -oE -m1 '[0-9]+\\.[0-9.]+'"), topic: versions
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/local/epicore/main.nf
+++ b/modules/local/epicore/main.nf
@@ -16,7 +16,7 @@ process EPICORE {
         path "${result_tsv}",                       emit: final_epicore_tsv
         path "epicore_length_distribution.html",    emit: length_dist
         path "epicore_intensity_histogram.html",    emit: intensity_hist
-        tuple val("${task.process}"), val('epicore'), eval("echo \$(epicore --version) | grep 'epicore' | cut -d ' ' -f3 | cut -c2-"), topic: versions
+        tuple val("${task.process}"), val('epicore'), eval("epicore --version | grep 'epicore' | cut -d ' ' -f3 | cut -c2-"), topic: versions
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/local/untar/main.nf
+++ b/modules/local/untar/main.nf
@@ -12,7 +12,7 @@ process UNTAR {
 
     output:
     tuple val(meta), path("*.d"), emit: untar
-    tuple val("${task.process}"), val('untar'), eval('tar --version 2>&1 | head -1 | sed "s/^.*(GNU tar) //; s/ Copyright.*//"'), topic: versions
+    tuple val("${task.process}"), val('untar'), eval("tar --version 2>&1 | grep -oE -m1 '[0-9]+\\.[0-9.]+'"), topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/untar/main.nf
+++ b/modules/local/untar/main.nf
@@ -12,7 +12,7 @@ process UNTAR {
 
     output:
     tuple val(meta), path("*.d"), emit: untar
-    tuple val("${task.process}"), val('untar'), eval("echo \$(tar --version 2>&1) | sed 's/^.*(GNU tar) //; s/ Copyright.*\$//'"), topic: versions
+    tuple val("${task.process}"), val('untar'), eval('tar --version 2>&1 | head -1 | sed "s/^.*(GNU tar) //; s/ Copyright.*//"'), topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/unzip/main.nf
+++ b/modules/local/unzip/main.nf
@@ -12,7 +12,7 @@ process UNZIP {
 
     output:
     tuple val(meta), path("*.d"), emit: unzipped_archive
-    tuple val("${task.process}"), val('7za'), eval("7za --help 2>&1 | sed -nE 's/.*p7zip Version ([0-9.]+).*/\\1/p'"), topic: versions
+    tuple val("${task.process}"), val('7za'), eval("7za --help 2>&1 | grep -oE -m1 '[0-9]+\\.[0-9.]+'"), topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/unzip/main.nf
+++ b/modules/local/unzip/main.nf
@@ -12,7 +12,7 @@ process UNZIP {
 
     output:
     tuple val(meta), path("*.d"), emit: unzipped_archive
-    tuple val("${task.process}"), val('7za'), eval("echo \$(7za --help) | sed 's/.*p7zip Version //; s/(.*//'"), topic: versions
+    tuple val("${task.process}"), val('7za'), eval("7za --help 2>&1 | sed -nE 's/.*p7zip Version ([0-9.]+).*/\\1/p'"), topic: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
Fixes #452 — `UNTAR`, `UNZIP` and `EPICORE` captured their tool version via an `eval` output of the form `echo $(...)`, whose unquoted command substitution spliced parenthesis-containing version banners into the `bash -c` string and aborted the process, so every compressed Bruker `.d` input failed; replaced with direct command pipelines (no command substitution).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
