### PR TITLE
Fix order-dependent combine(by:) silently dropping samples in QUANT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core template 4.0.2 [#454](https://github.com/nf-core/mhcquant/pull/454)
 - Updated all nf-core modules to their latest versions [#454](https://github.com/nf-core/mhcquant/pull/454)
 
+### `Fixed`
+
+- Fixed silent per-sample drop from order-dependent `combine(by:)` in QUANT [#460](https://github.com/nf-core/mhcquant/pull/460)
+
 ### `Dependencies`
 
 | Dependency | Old version | New version |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - Fixed silent per-sample drop from order-dependent `combine(by:)` in QUANT [#460](https://github.com/nf-core/mhcquant/pull/460)
+- Fixed non-reproducible per-replicate column order in quantification output from unsorted `groupTuple()` [#460](https://github.com/nf-core/mhcquant/pull/460)
 
 ### `Dependencies`
 

--- a/subworkflows/local/process_feature/main.nf
+++ b/subworkflows/local/process_feature/main.nf
@@ -16,8 +16,7 @@ workflow PROCESS_FEATURE {
     OPENMS_FEATUREFINDERIDENTIFICATION(ch_runs_to_be_quantified).featurexml
         .map { meta, featurexml -> [groupKey([id: "${meta.sample}_${meta.condition}"], meta.group_count), featurexml] }
         .groupTuple()
-        // groupTuple() emits in task-arrival order, which sets the consensus map (rt_N/mz_N/intensity_N)
-        // column order. Sort by the leading run ID so per-replicate columns are reproducible across runs.
+        // Sort by run ID so consensus map column order is reproducible
         .map { key, featurexmls -> [key, featurexmls.sort { it.name.tokenize('_')[0] as int }] }
         .set { ch_featuresxmls }
 

--- a/subworkflows/local/process_feature/main.nf
+++ b/subworkflows/local/process_feature/main.nf
@@ -16,6 +16,9 @@ workflow PROCESS_FEATURE {
     OPENMS_FEATUREFINDERIDENTIFICATION(ch_runs_to_be_quantified).featurexml
         .map { meta, featurexml -> [groupKey([id: "${meta.sample}_${meta.condition}"], meta.group_count), featurexml] }
         .groupTuple()
+        // groupTuple() emits in task-arrival order, which sets the consensus map (rt_N/mz_N/intensity_N)
+        // column order. Sort by the leading run ID so per-replicate columns are reproducible across runs.
+        .map { key, featurexmls -> [key, featurexmls.sort { it.name.tokenize('_')[0] as int }] }
         .set { ch_featuresxmls }
 
     ch_featuresxmls

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -45,9 +45,7 @@ workflow QUANT {
         // Manipulate such that [meta_run1, idxml_run1, pout_group1], [meta_run2, idxml_run2, pout_group1] ...
         ch_runs_score_switched
             .map { meta, idxml -> [groupKey([id: "${meta.sample}_${meta.condition}"], meta.group_count) , meta, idxml] }
-            // Unwrap to the plain [id] map before combining: GroupKey.equals() is asymmetric
-            // (groupKey.equals(map)==true but map.equals(groupKey)==false), so a groupKey-vs-map combine
-            // silently drops pairs depending on operand arrival order (nextflow-io/nextflow#4104).
+            // Unwrap to plain [id] map: asymmetric GroupKey.equals() makes combine() drop pairs by arrival order (nextflow-io/nextflow#4104)
             .map { key, meta, idxml -> [key.getGroupTarget(), meta, idxml] }
             .combine(filter_q_value, by:0)
             .map { group_meta, meta, idxml, q_value -> [meta, idxml, q_value] }

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -44,8 +44,13 @@ workflow QUANT {
 
         // Manipulate such that [meta_run1, idxml_run1, pout_group1], [meta_run2, idxml_run2, pout_group1] ...
         ch_runs_score_switched
-            // Nextflow can only combine/join on the exact groupKey object, merge_id is not sufficient
             .map { meta, idxml -> [groupKey([id: "${meta.sample}_${meta.condition}"], meta.group_count) , meta, idxml] }
+            // Combine on the unwrapped key.target ([id] map), NOT the groupKey object: GroupKey.equals()
+            // is asymmetric (groupKey.equals(map)==true but map.equals(groupKey)==false), so a
+            // groupKey-vs-map combine silently drops pairs depending on operand arrival order on AWS Batch
+            // (nextflow-io/nextflow#4104). filter_q_value carries the same [id] map, so map-vs-map equals
+            // is symmetric and order-independent.
+            .map { key, meta, idxml -> [key.target, meta, idxml] }
             .combine(filter_q_value, by:0)
             .map { group_meta, meta, idxml, q_value -> [meta, idxml, q_value] }
             .set { ch_runs_to_filter}

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -45,12 +45,10 @@ workflow QUANT {
         // Manipulate such that [meta_run1, idxml_run1, pout_group1], [meta_run2, idxml_run2, pout_group1] ...
         ch_runs_score_switched
             .map { meta, idxml -> [groupKey([id: "${meta.sample}_${meta.condition}"], meta.group_count) , meta, idxml] }
-            // Combine on the unwrapped key.target ([id] map), NOT the groupKey object: GroupKey.equals()
-            // is asymmetric (groupKey.equals(map)==true but map.equals(groupKey)==false), so a
-            // groupKey-vs-map combine silently drops pairs depending on operand arrival order on AWS Batch
-            // (nextflow-io/nextflow#4104). filter_q_value carries the same [id] map, so map-vs-map equals
-            // is symmetric and order-independent.
-            .map { key, meta, idxml -> [key.target, meta, idxml] }
+            // Unwrap to the plain [id] map before combining: GroupKey.equals() is asymmetric
+            // (groupKey.equals(map)==true but map.equals(groupKey)==false), so a groupKey-vs-map combine
+            // silently drops pairs depending on operand arrival order (nextflow-io/nextflow#4104).
+            .map { key, meta, idxml -> [key.getGroupTarget(), meta, idxml] }
             .combine(filter_q_value, by:0)
             .map { group_meta, meta, idxml, q_value -> [meta, idxml, q_value] }
             .set { ch_runs_to_filter}


### PR DESCRIPTION
Unwrap the `groupKey` to its plain `[id]` map before `combine(by:0)` in the QUANT subworkflow. `GroupKey.equals()` is asymmetric, so the groupKey-vs-map combine silently dropped samples depending on task arrival order (jittery on AWS Batch). Closes #459.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).