### PR TITLE
Restore documented samplesheet validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core template 4.0.2 [#454](https://github.com/nf-core/mhcquant/pull/454)
 - Updated all nf-core modules to their latest versions [#454](https://github.com/nf-core/mhcquant/pull/454)
 
+### `Fixed`
+
+- Restored documented samplesheet validation errors for malformed input [#463](https://github.com/nf-core/mhcquant/pull/463)
+
 ### `Dependencies`
 
 | Dependency | Old version | New version |

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -18,18 +18,8 @@
                     "description": "Input: samplesheet TSV, SDRF file (.sdrf.tsv), or PRIDE accession (PXD...)",
                     "help_text": "Accepts three input modes:\n\n1. **Samplesheet TSV** (default): Tab-separated file with columns ID, Sample, Condition, ReplicateFileName.\n2. **SDRF file** (`.sdrf.tsv`): Files are downloaded from PRIDE automatically. Requires `--fasta`.\n3. **PRIDE accession** (e.g., `PXD009752`): SDRF and raw files are fetched from PRIDE. Requires `--fasta`.",
                     "fa_icon": "fas fa-file",
-                    "allOf": [
-                        {
-                            "if": {
-                                "allOf": [{ "pattern": "\\.tsv$" }, { "not": { "pattern": "\\.sdrf\\.tsv$" } }]
-                            },
-                            "then": {
-                                "format": "file-path",
-                                "exists": true,
-                                "schema": "assets/schema_input.json"
-                            }
-                        }
-                    ]
+                    "if": { "pattern": "\\.tsv$", "not": { "pattern": "\\.sdrf\\.tsv$" } },
+                    "then": { "format": "file-path", "exists": true, "schema": "assets/schema_input.json" }
                 },
                 "outdir": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -17,7 +17,19 @@
                     "pattern": "^(PXD\\d{6,}|\\S+\\.sdrf\\.tsv|\\S+\\.tsv)$",
                     "description": "Input: samplesheet TSV, SDRF file (.sdrf.tsv), or PRIDE accession (PXD...)",
                     "help_text": "Accepts three input modes:\n\n1. **Samplesheet TSV** (default): Tab-separated file with columns ID, Sample, Condition, ReplicateFileName.\n2. **SDRF file** (`.sdrf.tsv`): Files are downloaded from PRIDE automatically. Requires `--fasta`.\n3. **PRIDE accession** (e.g., `PXD009752`): SDRF and raw files are fetched from PRIDE. Requires `--fasta`.",
-                    "fa_icon": "fas fa-file"
+                    "fa_icon": "fas fa-file",
+                    "allOf": [
+                        {
+                            "if": {
+                                "allOf": [{ "pattern": "\\.tsv$" }, { "not": { "pattern": "\\.sdrf\\.tsv$" } }]
+                            },
+                            "then": {
+                                "format": "file-path",
+                                "exists": true,
+                                "schema": "assets/schema_input.json"
+                            }
+                        }
+                    ]
                 },
                 "outdir": {
                     "type": "string",

--- a/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
@@ -103,7 +103,9 @@ workflow PIPELINE_INITIALISATION {
 
     if (inputType == 'sdrf' || inputType == 'pride_id') {
         //
-        // SDRF / PRIDE input mode: fetch SDRF, convert, download files
+        // SDRF / PRIDE input mode: fetch SDRF, convert, download files.
+        // The samplesheet is produced by a process, so it is only available as a
+        // channel and must be validated lazily inside an operator.
         //
         def sdrf_path  = (inputType == 'sdrf') ? params.input : null
         def pride_id   = (inputType == 'pride_id') ? params.input : null
@@ -115,15 +117,24 @@ workflow PIPELINE_INITIALISATION {
 
         SDRF_TO_SAMPLESHEET(sdrf_path, pride_id)
 
-        ch_samplesheet_file = SDRF_TO_SAMPLESHEET.out.samplesheet
         ch_presets_file = SDRF_TO_SAMPLESHEET.out.search_presets
+        ch_samplesheet_rows = SDRF_TO_SAMPLESHEET.out.samplesheet
+            .flatMap { samplesheet_path ->
+                samplesheetToList(samplesheet_path.toString(), "${projectDir}/assets/schema_input.json")
+            }
 
     } else {
         //
-        // Standard samplesheet input mode
+        // Standard samplesheet input mode. Content is validated up front by
+        // validateParameters() via the conditional `schema` on the input param
+        // (nextflow_schema.json), which prints the documented per-field error. Parse
+        // eagerly here too so failures abort before any process is launched, rather than
+        // surfacing as a wrapped InvocationTargetException from inside a channel operator.
         //
-        ch_samplesheet_file = channel.value(params.input)
         ch_presets_file = channel.fromPath(params.search_presets, checkIfExists: true)
+        ch_samplesheet_rows = channel.fromList(
+            samplesheetToList(params.input, "${projectDir}/assets/schema_input.json")
+        )
     }
 
     //
@@ -145,12 +156,9 @@ workflow PIPELINE_INITIALISATION {
         }
 
     //
-    // Parse samplesheet with nf-schema validation, enrich, resolve search params (shared)
+    // Enrich rows and resolve search params (shared)
     //
-    ch_samplesheet_file
-        .flatMap { samplesheet_path ->
-            samplesheetToList(samplesheet_path.toString(), "${projectDir}/assets/schema_input.json")
-        }
+    ch_samplesheet_rows
         .map { meta, file, fasta ->
             def m = meta + [sample: meta.sample.toString(), condition: meta.condition.toString()]
             [m.subMap('sample', 'condition'), m, file, fasta]

--- a/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
@@ -103,9 +103,7 @@ workflow PIPELINE_INITIALISATION {
 
     if (inputType == 'sdrf' || inputType == 'pride_id') {
         //
-        // SDRF / PRIDE input mode: fetch SDRF, convert, download files.
-        // The samplesheet is produced by a process, so it is only available as a
-        // channel and must be validated lazily inside an operator.
+        // SDRF / PRIDE input: samplesheet is produced by a process, so validate lazily.
         //
         def sdrf_path  = (inputType == 'sdrf') ? params.input : null
         def pride_id   = (inputType == 'pride_id') ? params.input : null
@@ -125,11 +123,7 @@ workflow PIPELINE_INITIALISATION {
 
     } else {
         //
-        // Standard samplesheet input mode. Content is validated up front by
-        // validateParameters() via the conditional `schema` on the input param
-        // (nextflow_schema.json), which prints the documented per-field error. Parse
-        // eagerly here too so failures abort before any process is launched, rather than
-        // surfacing as a wrapped InvocationTargetException from inside a channel operator.
+        // Standard samplesheet: parse eagerly so validation fails fast with a documented error.
         //
         ch_presets_file = channel.fromPath(params.search_presets, checkIfExists: true)
         ch_samplesheet_rows = channel.fromList(


### PR DESCRIPTION
## Description

Since PRIDE/SDRF input support was added, a malformed samplesheet (e.g. a spectra file with an unsupported extension) no longer produced the clear, documented error it did in v3.1. The detailed per-field message got buried in `.nextflow.log` and the run rendered the full process list before failing with a generic `InvocationTargetException`, making it look like a runtime crash rather than input validation.

This restores up-front, documented validation by re-adding a **conditional** `schema` reference on the `input` param (applied only to `.tsv` samplesheets, skipped for `.sdrf.tsv` and `PXD…` accessions), and parses the standard samplesheet eagerly so failures abort before any process launches.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.