### PR TITLE
Fix Condition column validation to reject whitespace

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -20,7 +20,7 @@
             },
             "Condition": {
                 "type": ["string", "integer"],
-                "anyOf": [{ "type": "string", "pattern": "^\\S+-?" }, { "type": "integer" }],
+                "anyOf": [{ "type": "string", "pattern": "^\\S+$" }, { "type": "integer" }],
                 "errorMessage": "Sample condition must be provided and cannot contain spaces",
                 "meta": ["condition"]
             },


### PR DESCRIPTION
## PR checklist

Anchors the `Condition` samplesheet pattern to `^\S+$` so values containing spaces are rejected, matching the `Sample` column and the column's documented error message (the previous `^\S+-?` was unanchored and let e.g. `T2 DDA` pass).

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
