### PR TITLE
Bump nf-schema plugin to 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to nf-core template 4.0.2 [#454](https://github.com/nf-core/mhcquant/pull/454)
 - Updated all nf-core modules to their latest versions [#454](https://github.com/nf-core/mhcquant/pull/454)
 - Replaced local `pridepy/download_file` with upstream nf-core `pridepy/downloadfile` [#457](https://github.com/nf-core/mhcquant/pull/457)
+- Bumped `nf-schema` plugin to 2.7.2 [#465](https://github.com/nf-core/mhcquant/pull/465)
 
 ### `Fixed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -366,7 +366,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
## Description

Bumps the `nf-schema` Nextflow plugin from `2.5.1` to `2.7.2` (latest release) in `nextflow.config`.

This is a plugin version bump only; no pipeline logic, parameter schema, or samplesheet schema changes are included. CI (nf-test / pipeline validation) should confirm compatibility with the newer plugin.

### Changes

- `nextflow.config`: `nf-schema@2.5.1` -> `nf-schema@2.7.2`
- `CHANGELOG.md`: added an entry under the `3.3.0dev` `Changed` section