### PR TITLE
Add `--qpx_out` for qpx/quantms.io dataset export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added MultiQC plot for DeepLC retention time calibration per sample [#461](https://github.com/nf-core/mhcquant/pull/461)
 - Added MultiQC box plot of aligned residuals in the quant workflow [#462](https://github.com/nf-core/mhcquant/pull/462)
+- Added `--qpx_out` to emit a validated qpx/quantms.io dataset [#467](https://github.com/nf-core/mhcquant/pull/467)
 
 ### `Fixed`
 

--- a/bin/openms_to_qpx.py
+++ b/bin/openms_to_qpx.py
@@ -15,7 +15,8 @@ from qpx.writers import FeatureWriter, PsmWriter
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-RAW_FILE_EXTENSIONS = (".mzML", ".mzml", ".raw", ".RAW")
+# Longest/most-specific suffixes first so e.g. ".d.tar.gz" strips fully instead of stopping at ".d".
+RUN_FILE_EXTENSIONS = (".mzML.gz", ".d.tar.gz", ".d.zip", ".d.tar", ".featureXML", ".mzML", ".mzml", ".raw", ".RAW", ".d")
 PSM_DEDUP_KEYS = ["sequence", "charge", "run_file_name"]
 
 
@@ -45,7 +46,7 @@ def parse_arguments() -> argparse.Namespace:
 def normalize_run_name(filename: str) -> str:
     """qpx run_file_name is the raw data file stem; strip mhcquant's _cleaned/_aligned preprocessing suffixes to match the SDRF."""
     name = filename.rsplit("/", 1)[-1]
-    for ext in RAW_FILE_EXTENSIONS:
+    for ext in RUN_FILE_EXTENSIONS:
         if name.endswith(ext):
             name = name[: -len(ext)]
             break
@@ -161,6 +162,12 @@ def dedup_psm(rows: list) -> pd.DataFrame:
     return df.assign(_scan=scan_key).drop_duplicates(subset=[*PSM_DEDUP_KEYS, "_scan"]).drop(columns="_scan")
 
 
+def count_empty_run_names(df: pd.DataFrame) -> int:
+    if df.empty or "run_file_name" not in df.columns:
+        return 0
+    return int((df["run_file_name"] == "").sum())
+
+
 def reindex_and_write(df: pd.DataFrame, writer) -> int:
     """qpx writers do pa.Table.from_pandas(df, schema=...): every schema column must be present, so fill missing optional ones with None."""
     for column in writer.arrow_schema.names:
@@ -184,6 +191,13 @@ def main():
 
     psm_df = pd.concat(psm_frames, ignore_index=True) if psm_frames else pd.DataFrame()
     feature_df = pd.DataFrame(feature_rows)
+
+    n_empty = count_empty_run_names(psm_df) + count_empty_run_names(feature_df)
+    if n_empty:
+        raise SystemExit(
+            f"could not resolve run_file_name for {n_empty} rows; column headers empty and primaryMSRunPath "
+            "unavailable -- the qpx run/sample join would silently break"
+        )
 
     if psm_df.empty:
         logger.warning("No identified PSMs in any input consensusXML; writing empty psm/feature parquet.")

--- a/bin/openms_to_qpx.py
+++ b/bin/openms_to_qpx.py
@@ -112,7 +112,7 @@ def rows_from_consensusxml(path: str) -> tuple:
             scan=scan_numbers(pid),
             rt=float(pid.getRT()),
             additional_scores=[
-                {"score_name": pid.getScoreType(), "score_value": float(hit.getScore()), "higher_better": False}
+                {"score_name": pid.getScoreType(), "score_value": float(hit.getScore()), "higher_better": pid.isHigherScoreBetter()}
             ],
         )
 

--- a/bin/openms_to_qpx.py
+++ b/bin/openms_to_qpx.py
@@ -85,6 +85,18 @@ def rows_from_consensusxml(path: str) -> tuple:
     cm = oms.ConsensusMap()
     oms.ConsensusXMLFile().load(path, cm)
     run_by_map_index = {idx: normalize_run_name(header.filename) for idx, header in cm.getColumnHeaders().items()}
+    if any(not name for name in run_by_map_index.values()):
+        # mhcquant single-run consensus leaves the column header filename empty; the run name is in primaryMSRunPath
+        primary_runs = []
+        for protein_id in cm.getProteinIdentifications():
+            paths = []
+            protein_id.getPrimaryMSRunPath(paths)
+            primary_runs = [normalize_run_name(p.decode() if isinstance(p, bytes) else p) for p in paths]
+            if primary_runs:
+                break
+        for idx in sorted(run_by_map_index):
+            if not run_by_map_index[idx]:
+                run_by_map_index[idx] = primary_runs[idx] if idx < len(primary_runs) else (primary_runs[0] if primary_runs else "")
 
     psm_rows, feature_rows = [], []
     for cf in cm:
@@ -102,6 +114,14 @@ def rows_from_consensusxml(path: str) -> tuple:
         feature_handles = cf.getFeatureList()
         id_run = run_by_map_index.get(feature_handles[0].getMapIndex(), "NA") if feature_handles else "NA"
 
+        additional_scores = [
+            {"score_name": pid.getScoreType(), "score_value": float(hit.getScore()), "higher_better": pid.isHigherScoreBetter()}
+        ]
+        if hit.metaValueExists("q-value"):
+            additional_scores.append(
+                {"score_name": "q-value", "score_value": float(hit.getMetaValue("q-value")), "higher_better": False}
+            )
+
         base = dict(
             sequence=sequence.toUnmodifiedString(),
             peptidoform=to_proforma(sequence),
@@ -111,10 +131,10 @@ def rows_from_consensusxml(path: str) -> tuple:
             observed_mz=float(pid.getMZ()),
             scan=scan_numbers(pid),
             rt=float(pid.getRT()),
-            additional_scores=[
-                {"score_name": pid.getScoreType(), "score_value": float(hit.getScore()), "higher_better": pid.isHigherScoreBetter()}
-            ],
+            additional_scores=additional_scores,
         )
+        if hit.metaValueExists("MS:1001493"):
+            base["posterior_error_probability"] = float(hit.getMetaValue("MS:1001493"))
 
         psm_rows.append({**base, "run_file_name": id_run, "protein_accessions": protein_accessions or [anchor_protein]})
 

--- a/bin/openms_to_qpx.py
+++ b/bin/openms_to_qpx.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# Written by Jonas Scheid and released under MIT license.
+
+"""Convert mhcquant consensusXML file(s) into qpx psm.parquet and feature.parquet."""
+
+import argparse
+import logging
+import os
+import re
+
+import pandas as pd
+import pyopenms as oms
+from qpx.writers import FeatureWriter, PsmWriter
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+RAW_FILE_EXTENSIONS = (".mzML", ".mzml", ".raw", ".RAW")
+PSM_DEDUP_KEYS = ["sequence", "charge", "run_file_name"]
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert mhcquant consensusXML file(s) into qpx psm.parquet and feature.parquet."
+    )
+    parser.add_argument(
+        "--consensusxml",
+        required=True,
+        nargs="+",
+        help="One or more consensusXML files (e.g. one per Sample+Condition group) to convert.",
+    )
+    parser.add_argument(
+        "--accession",
+        required=True,
+        help="Project accession, used as the output file name prefix.",
+    )
+    parser.add_argument(
+        "--outdir",
+        required=True,
+        help="Output directory for <accession>.psm.parquet and <accession>.feature.parquet.",
+    )
+    return parser.parse_args()
+
+
+def normalize_run_name(filename: str) -> str:
+    """qpx run_file_name is the raw data file stem; strip mhcquant's _cleaned/_aligned preprocessing suffixes to match the SDRF."""
+    name = filename.rsplit("/", 1)[-1]
+    for ext in RAW_FILE_EXTENSIONS:
+        if name.endswith(ext):
+            name = name[: -len(ext)]
+            break
+    name = re.sub(r"_aligned$", "", name)
+    name = re.sub(r"_cleaned$", "", name)
+    return name
+
+
+def to_proforma(aa_sequence: "oms.AASequence") -> str:
+    """Render an OpenMS AASequence (incl. N-/C-terminal mods) as ProForma using UniMod accessions."""
+    proforma = ""
+    n_term = aa_sequence.getNTerminalModification()
+    if n_term and n_term.getUniModAccession():
+        proforma += "[" + n_term.getUniModAccession().replace("UniMod:", "UNIMOD:") + "]-"
+    for i in range(aa_sequence.size()):
+        residue = aa_sequence.getResidue(i)
+        proforma += residue.getOneLetterCode()
+        mod = residue.getModification()
+        if mod and mod.getUniModAccession():
+            proforma += "[" + mod.getUniModAccession().replace("UniMod:", "UNIMOD:") + "]"
+    c_term = aa_sequence.getCTerminalModification()
+    if c_term and c_term.getUniModAccession():
+        proforma += "-[" + c_term.getUniModAccession().replace("UniMod:", "UNIMOD:") + "]"
+    return proforma
+
+
+def scan_numbers(peptide_id: "oms.PeptideIdentification") -> list:
+    spectrum_ref = (
+        peptide_id.getMetaValue("spectrum_reference") if peptide_id.metaValueExists("spectrum_reference") else ""
+    )
+    match = re.search(r"scan=(\d+)", spectrum_ref or "")
+    return [int(match.group(1))] if match else [0]
+
+
+def rows_from_consensusxml(path: str) -> tuple:
+    """Extract (psm_rows, feature_rows): one psm row per identified consensus feature, one feature row per contributing run."""
+    cm = oms.ConsensusMap()
+    oms.ConsensusXMLFile().load(path, cm)
+    run_by_map_index = {idx: normalize_run_name(header.filename) for idx, header in cm.getColumnHeaders().items()}
+
+    psm_rows, feature_rows = [], []
+    for cf in cm:
+        peptide_ids = cf.getPeptideIdentifications()
+        if not peptide_ids or not peptide_ids[0].getHits():
+            continue
+        pid = peptide_ids[0]
+        hit = pid.getHits()[0]
+        sequence = hit.getSequence()
+        charge = hit.getCharge()
+        target_decoy = hit.getMetaValue("target_decoy") if hit.metaValueExists("target_decoy") else "target"
+        protein_accessions = [ev.getProteinAccession() for ev in hit.getPeptideEvidences()]
+        anchor_protein = protein_accessions[0] if protein_accessions else "unknown"
+
+        feature_handles = cf.getFeatureList()
+        id_run = run_by_map_index.get(feature_handles[0].getMapIndex(), "NA") if feature_handles else "NA"
+
+        base = dict(
+            sequence=sequence.toUnmodifiedString(),
+            peptidoform=to_proforma(sequence),
+            charge=charge,
+            is_decoy=str(target_decoy).startswith("decoy"),
+            calculated_mz=float(sequence.getMZ(charge)),
+            observed_mz=float(pid.getMZ()),
+            scan=scan_numbers(pid),
+            rt=float(pid.getRT()),
+            additional_scores=[
+                {"score_name": pid.getScoreType(), "score_value": float(hit.getScore()), "higher_better": False}
+            ],
+        )
+
+        psm_rows.append({**base, "run_file_name": id_run, "protein_accessions": protein_accessions or [anchor_protein]})
+
+        for handle in feature_handles:
+            feature_rows.append(
+                {
+                    **base,
+                    "run_file_name": run_by_map_index.get(handle.getMapIndex(), "NA"),
+                    "anchor_protein": anchor_protein,
+                    "id_run_file_name": id_run,
+                    "intensities": [{"label": "label free sample", "intensity": float(handle.getIntensity())}],
+                }
+            )
+
+    return psm_rows, feature_rows
+
+
+def dedup_psm(rows: list) -> pd.DataFrame:
+    """ConsensusMap iteration can revisit the same PSM via nearby co-located features; scan is a list so extract a scalar key to dedup on."""
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+    scan_key = df["scan"].map(lambda scans: scans[0] if scans else -1)
+    return df.assign(_scan=scan_key).drop_duplicates(subset=[*PSM_DEDUP_KEYS, "_scan"]).drop(columns="_scan")
+
+
+def reindex_and_write(df: pd.DataFrame, writer) -> int:
+    """qpx writers do pa.Table.from_pandas(df, schema=...): every schema column must be present, so fill missing optional ones with None."""
+    for column in writer.arrow_schema.names:
+        if column not in df.columns:
+            df[column] = None
+    writer.write_dataframe(df[writer.arrow_schema.names])
+    writer.close()
+    return len(df)
+
+
+def main():
+    args = parse_arguments()
+    os.makedirs(args.outdir, exist_ok=True)
+
+    psm_frames, feature_rows = [], []
+    for path in args.consensusxml:
+        logger.info("Reading %s", path)
+        psm_rows, feat_rows = rows_from_consensusxml(path)
+        psm_frames.append(dedup_psm(psm_rows))
+        feature_rows.extend(feat_rows)
+
+    psm_df = pd.concat(psm_frames, ignore_index=True) if psm_frames else pd.DataFrame()
+    feature_df = pd.DataFrame(feature_rows)
+
+    if psm_df.empty:
+        logger.warning("No identified PSMs in any input consensusXML; writing empty psm/feature parquet.")
+
+    n_psm = reindex_and_write(psm_df, PsmWriter(os.path.join(args.outdir, f"{args.accession}.psm.parquet")))
+    n_feature = reindex_and_write(
+        feature_df, FeatureWriter(os.path.join(args.outdir, f"{args.accession}.feature.parquet"))
+    )
+    logger.info("Wrote %d psm rows and %d feature rows to %s", n_psm, n_feature, args.outdir)
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -539,9 +539,9 @@ process {
         ]
     }
 
-    withName: '.*:QPX_EXPORT' {
+    withName: 'QPX_EXPORT' {
         publishDir  = [
-            path: {"${params.outdir}/qpx"},
+            path: {"${params.outdir}"},
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -538,6 +538,13 @@ process {
             enabled: false
         ]
     }
+
+    withName: '.*:QPX_EXPORT' {
+        publishDir  = [
+            path: {"${params.outdir}/qpx"},
+            mode: params.publish_dir_mode
+        ]
+    }
 }
 
 process {

--- a/docs/output.md
+++ b/docs/output.md
@@ -14,6 +14,7 @@ The directories listed below will be created in the results directory after the 
 - `*.mzTab` (if `--quantify` is specified)
 - `global_fdr/global.tsv` (if `--global_fdr` is specified)
 - `spectrum_library/*_speclib.tsv` (if `--generate_speclib` is specified)
+- `qpx/<accession>.*.parquet` (if `--qpx_out` is specified)
 
 #### TSV
 
@@ -52,6 +53,10 @@ PEP  sequence  accession  best_search_engine_score[1]  retention_time  charge  m
 ```
 
 By default (only identification) the `best_search_engine_score[1]` holds the percolator q-value. If `--quantify` is specified the Comet XCorr of each peptide identification is annotated in the `best_search_engine_score[1]` column and peptide quantities in the `peptide_abundance_study_variable` columns.
+
+#### qpx
+
+When `--qpx_out` is specified (requires `--quantify` and an SDRF input), the `qpx/` directory holds one project-level [qpx / quantms.io](https://quantms.org) dataset: `<accession>.{psm,feature,sample,run,ontology,provenance,dataset}.parquet`. The peptide-level `psm` and `feature` tables carry the identifications and per-run quantities; the remaining tables carry SDRF-derived sample/run metadata. The dataset is validated with `qpxc validate` and is directly consumable by the bigbio/quantms toolchain.
 
 #### Global FDR
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -181,6 +181,21 @@ When quantification is enabled, the pipeline performs retention time alignment a
 
 The quantification workflow produces a ConsensusXML file containing integrated peak areas for identified peptides across all samples.
 
+### qpx / quantms.io export
+
+With `--qpx_out`, the pipeline emits a validated [qpx / quantms.io](https://quantms.org) dataset (peptide-level `psm` and `feature` parquet tables plus SDRF-derived metadata) so results plug into the bigbio/quantms ecosystem. It requires `--quantify` and an [SDRF](#input-modes) input, which supplies the per-run sample metadata:
+
+```bash
+nextflow run nf-core/mhcquant \
+    --input 'PXD000000.sdrf.tsv' \
+    --fasta 'SWISSPROT_2020.fasta' \
+    --quantify \
+    --qpx_out \
+    -profile docker
+```
+
+A single project-level dataset is written to `qpx/<accession>.{psm,feature,sample,run,ontology,provenance,dataset}.parquet`.
+
 ## Spectrum Library Generation
 
 The pipeline can generate spectrum libraries suitable for DIA-based searches using the `--generate_speclib` parameter:

--- a/main.nf
+++ b/main.nf
@@ -32,6 +32,8 @@ workflow NFCORE_MHCQUANT {
     take:
     samplesheet // channel: samplesheet read in from --input
     fasta       // channel: reference database read in from --fasta
+    sdrf        // channel: raw SDRF file, empty for plain samplesheet input
+    accession   //    val: resolved PRIDE accession, '' for plain samplesheet input
 
     main:
 
@@ -41,6 +43,8 @@ workflow NFCORE_MHCQUANT {
     MHCQUANT (
         samplesheet,
         fasta,
+        sdrf,
+        accession,
         params.multiqc_config,
         params.multiqc_logo,
         params.multiqc_methods_description,
@@ -78,7 +82,9 @@ workflow {
     //
     NFCORE_MHCQUANT (
         PIPELINE_INITIALISATION.out.samplesheet,
-        PIPELINE_INITIALISATION.out.fasta
+        PIPELINE_INITIALISATION.out.fasta,
+        PIPELINE_INITIALISATION.out.sdrf,
+        PIPELINE_INITIALISATION.out.accession
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/modules/local/qpx/export/environment.yml
+++ b/modules/local/qpx/export/environment.yml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge

--- a/modules/local/qpx/export/environment.yml
+++ b/modules/local/qpx/export/environment.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::qpx=1.0.2

--- a/modules/local/qpx/export/main.nf
+++ b/modules/local/qpx/export/main.nf
@@ -37,9 +37,6 @@ process QPX_EXPORT {
     stub:
     """
     mkdir -p qpx
-    touch qpx/${accession}.psm.parquet
-    touch qpx/${accession}.feature.parquet
-    touch qpx/${accession}.sdrf.tsv
-    touch qpx/${accession}-project.json
+    touch qpx/${accession}.{psm,feature,sample,run,ontology,provenance,dataset}.parquet
     """
 }

--- a/modules/local/qpx/export/main.nf
+++ b/modules/local/qpx/export/main.nf
@@ -10,7 +10,7 @@ process QPX_EXPORT {
 
     output:
     path 'qpx/**'                                                    , emit: qpx
-    tuple val("${task.process}"), val('qpx'), eval("qpxc --version"), topic: versions
+    tuple val("${task.process}"), val('qpx'), eval("qpxc --version | cut -d' ' -f2"), topic: versions
 
     script:
     """
@@ -23,6 +23,7 @@ process QPX_EXPORT {
         --qpx-dir core/ \\
         --sdrf-file ${sdrf} \\
         --project-accession ${accession} \\
+        --output-prefix ${accession} \\
         --output-folder qpx/
 
     qpxc validate --dataset-path qpx/

--- a/modules/local/qpx/export/main.nf
+++ b/modules/local/qpx/export/main.nf
@@ -1,0 +1,39 @@
+process QPX_EXPORT {
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/qpx:1.0.2--pyhdfd78af_1' :
+        'biocontainers/qpx:1.0.2--pyhdfd78af_1' }"
+
+    input:
+    tuple val(meta), path(consensusxmls), path(sdrf), val(accession)
+
+    output:
+    path 'qpx/**'                                                    , emit: qpx
+    tuple val("${task.process}"), val('qpx'), eval("qpxc --version"), topic: versions
+
+    script:
+    """
+    openms_to_qpx.py \\
+        --consensusxml ${consensusxmls.join(' ')} \\
+        --accession ${accession} \\
+        --outdir core/
+
+    qpxc convert openms \\
+        --qpx-dir core/ \\
+        --sdrf-file ${sdrf} \\
+        --project-accession ${accession} \\
+        --output-folder qpx/
+
+    qpxc validate --dataset-path qpx/
+    """
+
+    stub:
+    """
+    mkdir -p qpx
+    touch qpx/${accession}.psm.parquet
+    touch qpx/${accession}.feature.parquet
+    touch qpx/${accession}.sdrf.tsv
+    touch qpx/${accession}-project.json
+    """
+}

--- a/modules/local/qpx/export/main.nf
+++ b/modules/local/qpx/export/main.nf
@@ -1,4 +1,6 @@
 process QPX_EXPORT {
+    tag "${meta.id}"
+    label 'process_single'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -11,6 +13,9 @@ process QPX_EXPORT {
     output:
     path 'qpx/**'                                                    , emit: qpx
     tuple val("${task.process}"), val('qpx'), eval("qpxc --version | cut -d' ' -f2"), topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
 
     script:
     """

--- a/modules/local/qpx/export/meta.yml
+++ b/modules/local/qpx/export/meta.yml
@@ -1,0 +1,54 @@
+name: qpx_export
+description: Convert mhcquant consensusXML quantification results into a validated qpx/quantms.io parquet dataset
+keywords:
+  - immunopeptidomics
+  - quantms
+  - parquet
+  - quantification
+tools:
+  - qpx:
+      description: |
+        qpx (quantms.io) writes and validates the quantms.io parquet dataset format for
+        proteomics/immunopeptidomics quantification results.
+      homepage: https://quantms.org
+      licence: ["Apache-2.0"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'PXD000000' ]
+    - consensusxmls:
+        type: file
+        description: One or more consensusXML files, one per Sample+Condition group, to convert into the qpx dataset
+        pattern: "*.consensusXML"
+    - sdrf:
+        type: file
+        description: SDRF file describing the experimental design, required by qpxc to build the qpx dataset
+        pattern: "*.sdrf.tsv"
+    - accession:
+        type: string
+        description: Project accession, used as the qpx output file name prefix
+output:
+  qpx:
+    - "qpx/**":
+        type: file
+        description: Validated qpx/quantms.io parquet dataset (psm, feature, sample, run, ontology, provenance, dataset)
+        pattern: "qpx/*.parquet"
+        ontologies: []
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - qpx:
+          type: string
+          description: The name of the tool
+      - "qpxc --version | cut -d' ' -f2":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@jonasscheid"
+maintainers:
+  - "@jonasscheid"

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     filter_mzml                     = false
     generate_speclib                = false
     quantify                        = false
+    qpx_out                         = false
     annotate_ions                   = false
     epicore                         = false
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -356,6 +356,13 @@
                     "fa_icon": "fas fa-fast-forward",
                     "description": "Turn on quantification mode"
                 },
+                "qpx_out": {
+                    "type": "boolean",
+                    "default": false,
+                    "fa_icon": "fas fa-file-export",
+                    "description": "Emit a validated qpx/quantms.io dataset.",
+                    "help_text": "Requires --quantify and SDRF input."
+                },
                 "max_rt_alignment_shift": {
                     "type": "integer",
                     "fa_icon": "fas fa-align-center",

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -89,13 +89,14 @@ workflow QUANT {
 
         // Project-level fan-in: one qpx/quantms.io dataset across all Sample+Condition groups, not per-group
         if (params.qpx_out) {
-            // ch_accession is a value channel (DataflowVariable), not a String - combine it, never string-interpolate it.
-            // .collect() emits one list of every group's consensusXML, and .combine() flattens that list into the
-            // tuple, so each row is [cxml1, .., cxmlN, sdrf, accession] - slice by position to stay N-group safe.
+            // ch_accession is a scalar carried on a channel - combine() it into the tuple; never string-interpolate it into a script arg here.
+            // Wrap the collected consensusXML list into [meta, cxmls] first so combine() appends sdrf/accession
+            // as extra tuple fields instead of spreading the cxmls list itself.
             ch_qpx_in = PROCESS_FEATURE.out.consensusxml.map { _meta, cxml -> cxml }.collect()
+                .map { cxmls -> [ [id: 'qpx'], cxmls ] }
                 .combine( ch_sdrf.map { _m, f -> f } )
                 .combine( ch_accession )
-                .map { row -> [ [id: row[-1]], row[0..-3], row[-2], row[-1] ] }
+                .map { _meta, cxmls, sdrf_file, acc -> [ [id: acc], cxmls, sdrf_file, acc ] }
             QPX_EXPORT( ch_qpx_in )
         }
 

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -89,12 +89,13 @@ workflow QUANT {
 
         // Project-level fan-in: one qpx/quantms.io dataset across all Sample+Condition groups, not per-group
         if (params.qpx_out) {
-            ch_cxml = PROCESS_FEATURE.out.consensusxml.map { _meta, cxml -> cxml }.collect()
-            // ch_accession is a value channel (DataflowVariable), not a String - combine it, never string-interpolate it
-            ch_qpx_in = ch_cxml
+            // ch_accession is a value channel (DataflowVariable), not a String - combine it, never string-interpolate it.
+            // .collect() emits one list of every group's consensusXML, and .combine() flattens that list into the
+            // tuple, so each row is [cxml1, .., cxmlN, sdrf, accession] - slice by position to stay N-group safe.
+            ch_qpx_in = PROCESS_FEATURE.out.consensusxml.map { _meta, cxml -> cxml }.collect()
                 .combine( ch_sdrf.map { _m, f -> f } )
                 .combine( ch_accession )
-                .map { cxmls, sdrf_file, acc -> [ [id: acc], cxmls, sdrf_file, acc ] }
+                .map { row -> [ [id: row[-1]], row[0..-3], row[-2], row[-1] ] }
             QPX_EXPORT( ch_qpx_in )
         }
 

--- a/subworkflows/local/quant/main.nf
+++ b/subworkflows/local/quant/main.nf
@@ -10,6 +10,7 @@ include { OPENMS_IDSCORESWITCHER                   } from '../../../modules/nf-c
 include { OPENMS_IDFILTER as OPENMS_IDFILTER_QUANT } from '../../../modules/nf-core/openms/idfilter/main'
 include { OPENMS_IDMERGER as OPENMS_IDMERGER_QUANT } from '../../../modules/nf-core/openms/idmerger/main'
 include { OPENMS_MZTABEXPORTER                     } from '../../../modules/local/openms/mztabexporter'
+include { QPX_EXPORT                               } from '../../../modules/local/qpx/export'
 
 include { MAP_ALIGNMENT                            } from '../map_alignment'
 include { PROCESS_FEATURE                          } from '../process_feature'
@@ -20,6 +21,8 @@ workflow QUANT {
         merged_pout
         filter_q_value
         mzml
+        ch_sdrf
+        ch_accession
 
     main:
         // Split post-percolator idXML files and manipulate such that we end up with [meta_run1, idxml_run1] [meta_run2, idxml_run2] ...
@@ -83,6 +86,17 @@ workflow QUANT {
         PROCESS_FEATURE ( ch_runs_to_be_quantified )
 
         OPENMS_MZTABEXPORTER(PROCESS_FEATURE.out.consensusxml)
+
+        // Project-level fan-in: one qpx/quantms.io dataset across all Sample+Condition groups, not per-group
+        if (params.qpx_out) {
+            ch_cxml = PROCESS_FEATURE.out.consensusxml.map { _meta, cxml -> cxml }.collect()
+            // ch_accession is a value channel (DataflowVariable), not a String - combine it, never string-interpolate it
+            ch_qpx_in = ch_cxml
+                .combine( ch_sdrf.map { _m, f -> f } )
+                .combine( ch_accession )
+                .map { cxmls, sdrf_file, acc -> [ [id: acc], cxmls, sdrf_file, acc ] }
+            QPX_EXPORT( ch_qpx_in )
+        }
 
     emit:
         consensusxml = PROCESS_FEATURE.out.consensusxml

--- a/subworkflows/local/sdrf_to_samplesheet/main.nf
+++ b/subworkflows/local/sdrf_to_samplesheet/main.nf
@@ -63,6 +63,8 @@ workflow SDRF_TO_SAMPLESHEET {
     emit:
     samplesheet    = ch_samplesheet_file                                                       // path: samplesheet.tsv with local file paths
     search_presets = PARSESDRF_CONVERT.out.mhcquant.map { _meta, _samplesheet, presets -> presets }  // path: search_presets.tsv
+    sdrf           = ch_sdrf                                                                    // channel: [ meta, sdrf_file ]
+    accession      = resolved_accession                                                         //    val: resolved PRIDE accession
 }
 
 /*

--- a/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
@@ -101,6 +101,10 @@ workflow PIPELINE_INITIALISATION {
     //
     def inputType = detectInputType(params.input)
 
+    if (params.qpx_out && (!params.quantify || !(inputType in ['sdrf', 'pride_id']))) {
+        error("--qpx_out requires both --quantify and an SDRF/PRIDE input (--input <SDRF file> or PXD accession).")
+    }
+
     if (inputType == 'sdrf' || inputType == 'pride_id') {
         //
         // SDRF / PRIDE input: samplesheet is produced by a process, so validate lazily.

--- a/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_mhcquant_pipeline/main.nf
@@ -124,6 +124,8 @@ workflow PIPELINE_INITIALISATION {
             .flatMap { samplesheet_path ->
                 samplesheetToList(samplesheet_path.toString(), "${projectDir}/assets/schema_input.json")
             }
+        ch_sdrf      = SDRF_TO_SAMPLESHEET.out.sdrf
+        ch_accession = SDRF_TO_SAMPLESHEET.out.accession
 
     } else {
         //
@@ -133,6 +135,8 @@ workflow PIPELINE_INITIALISATION {
         ch_samplesheet_rows = channel.fromList(
             samplesheetToList(params.input, "${projectDir}/assets/schema_input.json")
         )
+        ch_sdrf      = channel.empty()
+        ch_accession = ''
     }
 
     //
@@ -219,6 +223,8 @@ workflow PIPELINE_INITIALISATION {
     emit:
     samplesheet = ch_samplesheet
     fasta       = ch_fasta
+    sdrf        = ch_sdrf        // channel: [ meta, sdrf_file ], empty for plain samplesheet input
+    accession   = ch_accession   //    val: resolved PRIDE accession, '' for plain samplesheet input
 }
 
 /*

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -11,4 +11,5 @@ intermediate_results/rescoring/*
 intermediate_results/ion_annotations/*
 global_fdr/global.tsv
 spectrum_library/*_speclib.tsv
+qpx/*.parquet
 *.tsv

--- a/tests/sdrf.nf.test
+++ b/tests/sdrf.nf.test
@@ -10,7 +10,9 @@ nextflow_pipeline {
 
         when {
             params {
-                outdir = "$outputDir"
+                outdir      = "$outputDir"
+                quantify    = true
+                qpx_out     = true
             }
         }
 

--- a/tests/sdrf.nf.test.snap
+++ b/tests/sdrf.nf.test.snap
@@ -12,6 +12,18 @@
                 "OPENMS_DECOYDATABASE": {
                     "openms": "3.5.0"
                 },
+                "OPENMS_FEATUREFINDERIDENTIFICATION": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_FILECONVERTER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDCONFLICTRESOLVER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDFILTER_QUANT": {
+                    "openms": "3.5.0"
+                },
                 "OPENMS_IDFILTER_Q_VALUE": {
                     "openms": "3.5.0"
                 },
@@ -19,6 +31,27 @@
                     "openms": "3.4.1"
                 },
                 "OPENMS_IDMERGER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDMERGER_QUANT": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDRIPPER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDSCORESWITCHER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_MAPALIGNERIDENTIFICATION": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_MAPRTTRANSFORMERIDXML": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_MAPRTTRANSFORMERMZML": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_MZTABEXPORTER": {
                     "openms": "3.5.0"
                 },
                 "OPENMS_PEPTIDEINDEXER": {
@@ -43,6 +76,9 @@
                 "PYOPENMS_CHROMATOGRAMEXTRACTOR": {
                     "pyopenms": "3.4.1"
                 },
+                "QPX_EXPORT": {
+                    "qpx": "1.0.2"
+                },
                 "SUMMARIZE_RESULTS": {
                     "pyopenms": "3.4.1"
                 },
@@ -55,13 +91,18 @@
             },
             [
                 "intermediate_results",
+                "intermediate_results/alignment",
+                "intermediate_results/alignment/IP_lung_1T_060317_1.trafoXML",
                 "intermediate_results/comet",
                 "intermediate_results/comet/IP_lung_1T_060317_1_pin.tsv",
+                "intermediate_results/features",
+                "intermediate_results/features/1_lc2_1.featureXML",
                 "intermediate_results/rescoring",
                 "intermediate_results/rescoring/lc2_1_ms2rescore.idXML",
                 "intermediate_results/rescoring/lc2_1_pout.idXML",
                 "intermediate_results/rescoring/lc2_1_pout_filtered.idXML",
                 "intermediate_results/rescoring/lc2_1_psm.idXML",
+                "lc2_1.mzTab",
                 "lc2_1.tsv",
                 "multiqc",
                 "multiqc/ms2rescore",
@@ -69,6 +110,7 @@
                 "multiqc/multiqc_data/llms-full.txt",
                 "multiqc/multiqc_data/multiqc.log",
                 "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_aligned_residuals.txt",
                 "multiqc/multiqc_data/multiqc_chromatogram.txt",
                 "multiqc/multiqc_data/multiqc_citations.txt",
                 "multiqc/multiqc_data/multiqc_data.json",
@@ -79,6 +121,7 @@
                 "multiqc/multiqc_data/multiqc_histogram_scores.txt",
                 "multiqc/multiqc_data/multiqc_length_dist.txt",
                 "multiqc/multiqc_data/multiqc_mass_error.txt",
+                "multiqc/multiqc_data/multiqc_peptide_intensity.txt",
                 "multiqc/multiqc_data/multiqc_percolator_barplot.txt",
                 "multiqc/multiqc_data/multiqc_scores_xcorr.txt",
                 "multiqc/multiqc_data/multiqc_software_versions.txt",
@@ -86,6 +129,7 @@
                 "multiqc/multiqc_data/percolator_plot.txt",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_plots/pdf",
+                "multiqc/multiqc_plots/pdf/aligned_residuals.pdf",
                 "multiqc/multiqc_plots/pdf/chromatogram-cnt.pdf",
                 "multiqc/multiqc_plots/pdf/chromatogram-log.pdf",
                 "multiqc/multiqc_plots/pdf/deeplc_rt_calibration.pdf",
@@ -95,10 +139,12 @@
                 "multiqc/multiqc_plots/pdf/histogram_scores.pdf",
                 "multiqc/multiqc_plots/pdf/length_dist.pdf",
                 "multiqc/multiqc_plots/pdf/mass_error.pdf",
+                "multiqc/multiqc_plots/pdf/peptide_intensity.pdf",
                 "multiqc/multiqc_plots/pdf/percolator_plot-cnt.pdf",
                 "multiqc/multiqc_plots/pdf/percolator_plot-pct.pdf",
                 "multiqc/multiqc_plots/pdf/scores_xcorr.pdf",
                 "multiqc/multiqc_plots/png",
+                "multiqc/multiqc_plots/png/aligned_residuals.png",
                 "multiqc/multiqc_plots/png/chromatogram-cnt.png",
                 "multiqc/multiqc_plots/png/chromatogram-log.png",
                 "multiqc/multiqc_plots/png/deeplc_rt_calibration.png",
@@ -108,10 +154,12 @@
                 "multiqc/multiqc_plots/png/histogram_scores.png",
                 "multiqc/multiqc_plots/png/length_dist.png",
                 "multiqc/multiqc_plots/png/mass_error.png",
+                "multiqc/multiqc_plots/png/peptide_intensity.png",
                 "multiqc/multiqc_plots/png/percolator_plot-cnt.png",
                 "multiqc/multiqc_plots/png/percolator_plot-pct.png",
                 "multiqc/multiqc_plots/png/scores_xcorr.png",
                 "multiqc/multiqc_plots/svg",
+                "multiqc/multiqc_plots/svg/aligned_residuals.svg",
                 "multiqc/multiqc_plots/svg/chromatogram-cnt.svg",
                 "multiqc/multiqc_plots/svg/chromatogram-log.svg",
                 "multiqc/multiqc_plots/svg/deeplc_rt_calibration.svg",
@@ -121,17 +169,29 @@
                 "multiqc/multiqc_plots/svg/histogram_scores.svg",
                 "multiqc/multiqc_plots/svg/length_dist.svg",
                 "multiqc/multiqc_plots/svg/mass_error.svg",
+                "multiqc/multiqc_plots/svg/peptide_intensity.svg",
                 "multiqc/multiqc_plots/svg/percolator_plot-cnt.svg",
                 "multiqc/multiqc_plots/svg/percolator_plot-pct.svg",
                 "multiqc/multiqc_plots/svg/scores_xcorr.svg",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
                 "pipeline_info/nf_core_mhcquant_software_mqc_versions.yml",
+                "qpx",
+                "qpx/PXD009752.dataset.parquet",
+                "qpx/PXD009752.feature.parquet",
+                "qpx/PXD009752.ontology.parquet",
+                "qpx/PXD009752.provenance.parquet",
+                "qpx/PXD009752.psm.parquet",
+                "qpx/PXD009752.run.parquet",
+                "qpx/PXD009752.sample.parquet",
                 "sdrf",
                 "sdrf/PXD009752_presets.tsv",
                 "sdrf/PXD009752_samplesheet.tsv"
             ],
             [
+                "IP_lung_1T_060317_1.trafoXML:md5,e9d83810baeb6e78d6c80c60b998efaa",
+                "1_lc2_1.featureXML:md5,9e1f49a53f3d7f6abdcaebdd8899eb96",
+                "lc2_1.mzTab:md5,98a76f6e59def39221e545be94e17d1a",
                 "PXD009752_presets.tsv:md5,3ba3b5c24f71025bfc1799ea87cd0a12",
                 "PXD009752_samplesheet.tsv:md5,4d7d2f1ca8d3def75b05ae8c01c481d8"
             ],
@@ -140,12 +200,17 @@
                     "lc2_1.tsv",
                     [
                         "AEDGLKHEY",
+                        "AEDGLKHEY",
                         "AEDKENYKKF",
+                        "AEDKENYKKF",
+                        "AEDKENYKKFY",
                         "AEDKENYKKFY",
                         "AEGTLSKKL",
                         "AEKELHEKF",
                         "ATAQFKINKK",
+                        "ATAQFKINKK",
                         "ATEQPLTAK",
+                        "ATEQPLTAKK",
                         "ATEQPLTAKK",
                         "ATFPGMWER",
                         "ATNKITIIFK",
@@ -154,6 +219,8 @@
                         "AVIQVSQIVAR",
                         "AVQEFGLAR",
                         "AVQEFGLARFK",
+                        "AVQEFGLARFK",
+                        "AVSEGTKAVTK",
                         "AVSEGTKAVTK",
                         "AVTDQTVSK",
                         "AVTKYTSSK",
@@ -163,8 +230,10 @@
                         "EEDPNTHILY",
                         "EEIEILLRY",
                         "EELQKIYKTY",
+                        "EELQKIYKTY",
                         "EERVINEEY",
                         "EETPVVLQL",
+                        "EEVPKRKW",
                         "EEVPKRKW",
                         "EILKWYLNK",
                         "FPAGKVPAF",
@@ -175,11 +244,15 @@
                         "GSLGFTVTK",
                         "GSQAGGSQTLK",
                         "GSSPEQVVRPK",
+                        "GSSPEQVVRPK",
+                        "GSYNKVFLAK",
                         "GSYNKVFLAK",
                         "GTFLEGVAK",
                         "GTIHAGQPVK",
                         "GTNVNMPVSK",
                         "GTVDKKMVEK",
+                        "GTVDKKMVEK",
+                        "GTVTPPPRLVK",
                         "GTVTPPPRLVK",
                         "HFDPEVVQI",
                         "HPDTGISSKAM",
@@ -191,12 +264,14 @@
                         "IVADHVASY",
                         "IYLPYLHEW",
                         "KAFNQGKIFK",
+                        "KAFNQGKIFK",
                         "KEIFLRELI",
                         "KEIPN(Deamidated)FPTL",
                         "KPITTGGVTY",
                         "KSFDTSLIRK",
                         "KVLHFFNVK",
                         "KYLADLPTL",
+                        "KYVKVFHKF",
                         "KYVKVFHKF",
                         "LPAKDIQTNVY",
                         "LPALLEKNAM",
@@ -221,7 +296,10 @@
                         "QPFREAIAL",
                         "QPWEEIKTSY",
                         "RILFFNTPK",
+                        "RILFFNTPK",
                         "RTLQQMLLK",
+                        "RTLQQMLLK",
+                        "RVLDVTKKK",
                         "RVLDVTKKK",
                         "RYGPQFTL",
                         "RYIRDAHTF",
@@ -234,6 +312,8 @@
                         "SEIAQKQKL",
                         "SELAEDKENY",
                         "SEN(Deamidated)ELKKAY",
+                        "SEN(Deamidated)ELKKAY",
+                        "SENELKKAY",
                         "SENELKKAY",
                         "SFSPKTYSF",
                         "SGSSYLNTVQK",
@@ -243,19 +323,23 @@
                         "SSADGSQPPK",
                         "SSIQGQWPK",
                         "SSLYIILKK",
+                        "SSLYIILKK",
                         "STDERAYQR",
                         "STEKIYIRK",
                         "STLAVTSQK",
                         "STMGYMMAK",
                         "STMGYMMAKK",
+                        "STMGYMMAKK",
                         "SVAELRSQK",
                         "SVIVQPFSK",
+                        "SVPREPIDRK",
                         "SVPREPIDRK",
                         "SVSQPVAQK",
                         "SYGSVFKAI",
                         "SYIAAISARF",
                         "SYQRAFNEF",
                         "TAADTAVYY",
+                        "TEHYDIPKVSW",
                         "TEHYDIPKVSW",
                         "TENKERKSF",
                         "TFMDRGFVF",
@@ -265,16 +349,20 @@
                         "TVSETFMSK",
                         "TYIDKSTQL",
                         "TYNKVLHFF",
+                        "TYNKVLHFF",
                         "VPPVFVVSY",
                         "VPSPAQIMY",
                         "VPVEEQEEF",
                         "VSEGTKAVTK",
                         "VTQSEIAQK",
                         "VTQSEIAQKQK",
+                        "VTQSEIAQKQK",
                         "VVQEPGQVFK",
                         "VWSDVTPLTF",
                         "VYEGPELNHAF",
                         "VYIKHPVSL",
+                        "VYIKHPVSL",
+                        "VYNKVHITL",
                         "VYNKVHITL",
                         "YIKHPVSL",
                         "YYDVAKQLL",
@@ -283,7 +371,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-06-11T12:35:15.842389067",
+        "timestamp": "2026-07-21T19:57:52.750597051",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -177,7 +177,7 @@ workflow MHCQUANT {
     // SUBWORKFLOW: QUANT
     //
     if (params.quantify) {
-        QUANT(merge_meta_map, RESCORE.out.rescored_runs, RESCORE.out.fdr_filtered, ch_clean_mzml_file)
+        QUANT(merge_meta_map, RESCORE.out.rescored_runs, RESCORE.out.fdr_filtered, ch_clean_mzml_file, ch_sdrf, ch_accession)
         ch_output = QUANT.out.consensusxml.mix(RESCORE.out.fdr_filtered_empty)
     } else {
         ch_output = RESCORE.out.fdr_filtered.mix(RESCORE.out.fdr_filtered_empty)

--- a/workflows/mhcquant.nf
+++ b/workflows/mhcquant.nf
@@ -55,6 +55,8 @@ workflow MHCQUANT {
     take:
     ch_samplesheet // channel: samplesheet read in from --input
     ch_fasta       // channel: reference database read in from --fasta
+    ch_sdrf        // channel: raw SDRF file, empty for plain samplesheet input
+    ch_accession   //    val: resolved PRIDE accession, '' for plain samplesheet input
     multiqc_config
     multiqc_logo
     multiqc_methods_description


### PR DESCRIPTION
## Description

Adds `--qpx_out`: emits a validated, project-level [qpx / quantms.io](https://quantms.org) dataset (peptide-level `psm` + `feature` parquet plus SDRF-derived metadata tables) from DDA immunopeptidomics quantification, so results plug into the bigbio/quantms ecosystem. Requires `--quantify` and an SDRF input.

- Peptide-only (no protein-group `pg` table) — immunopeptidomics cannot reliably quantify proteins, and qpx treats `pg` as optional.
- `bin/openms_to_qpx.py` builds the `psm`/`feature` parquet from the consensusXML via qpx's own schema-validated writers; the `QPX_EXPORT` module then runs `qpxc convert openms` + `qpxc validate`.
- SDRF nf-test extended with `--qpx_out` to cover the path in CI.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/mhcquant/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/mhcquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository. — N/A (reuses the existing PXD009752 SDRF test data)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes — SDRF nf-test with `--qpx_out` passes locally; full suite not yet run.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors). — N/A
